### PR TITLE
Implement source transports (PgSource, HttpSource, SparqlSource, ArchiveSource)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.venv/
+*.db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 description = "WXYC library catalog access and operations — CatalogSource protocol, SQLite export, artist enrichment, label extraction."
 requires-python = ">=3.11"
 dependencies = [
+    "asyncpg>=0.29.0",
+    "httpx>=0.25.0",
     "psycopg[binary]>=3.1",
     "wxyc-etl>=0.1.0",
 ]
@@ -12,6 +14,8 @@ dependencies = [
 mysql = ["pymysql>=1.0"]
 dev = [
     "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "pytest-httpx>=0.30.0",
     "ruff>=0.4.0",
     "pymysql>=1.0",
 ]
@@ -37,3 +41,4 @@ select = ["E", "F", "I", "W"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/src/wxyc_catalog/__init__.py
+++ b/src/wxyc_catalog/__init__.py
@@ -12,10 +12,18 @@ from wxyc_catalog.catalog_source import (
     create_catalog_source,
 )
 from wxyc_catalog.export_to_sqlite import export_rows_to_sqlite
+from wxyc_catalog.sources.archive import ArchiveSource
+from wxyc_catalog.sources.http import HttpSource
+from wxyc_catalog.sources.pg import PgSource
+from wxyc_catalog.sources.sparql import SparqlSource
 
 __all__ = [
+    "ArchiveSource",
     "BackendServiceSource",
     "CatalogSource",
+    "HttpSource",
+    "PgSource",
+    "SparqlSource",
     "TubafrenzySource",
     "create_catalog_source",
     "export_rows_to_sqlite",

--- a/src/wxyc_catalog/sources/__init__.py
+++ b/src/wxyc_catalog/sources/__init__.py
@@ -1,0 +1,8 @@
+"""Shared async transport classes for ETL data sources."""
+
+from wxyc_catalog.sources.archive import ArchiveSource
+from wxyc_catalog.sources.http import HttpSource
+from wxyc_catalog.sources.pg import PgSource
+from wxyc_catalog.sources.sparql import SparqlSource
+
+__all__ = ["PgSource", "HttpSource", "SparqlSource", "ArchiveSource"]

--- a/src/wxyc_catalog/sources/archive.py
+++ b/src/wxyc_catalog/sources/archive.py
@@ -34,9 +34,13 @@ class ArchiveSource:
             ``base_path``.
     """
 
-    def __init__(self, base_path: str | Path, *, index_path: str | Path | None = None) -> None:
+    def __init__(
+        self, base_path: str | Path, *, index_path: str | Path | None = None
+    ) -> None:
         self._base_path = Path(base_path)
-        self._index_path = Path(index_path) if index_path else self._base_path / "index.db"
+        self._index_path = (
+            Path(index_path) if index_path else self._base_path / "index.db"
+        )
         self._db: sqlite3.Connection | None = None
 
     def _get_db(self) -> sqlite3.Connection:

--- a/src/wxyc_catalog/sources/archive.py
+++ b/src/wxyc_catalog/sources/archive.py
@@ -1,7 +1,211 @@
-"""File loading from directories and tar archives with SQLite index caching."""
+"""File loading from directories and tar archives with SQLite index caching.
+
+Provides:
+- Load files from a directory by relative path
+- Load files from tar archives with an on-disk SQLite index for fast member lookup
+- Batch reads grouped by storage unit (directory or tar file)
+- List files matching a glob pattern
+- Async via ``asyncio.to_thread()`` for blocking filesystem I/O
+"""
 
 from __future__ import annotations
 
+import asyncio
+import logging
+import sqlite3
+import tarfile
+from collections import defaultdict
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
 
 class ArchiveSource:
-    """Placeholder — implementation pending."""
+    """File loading from directories and tar archives with SQLite index caching.
+
+    Paths are relative to ``base_path``. For tar archives, use the format
+    ``"archive.tar/member_name.json"`` where the first component is the tar
+    filename and the remainder is the member path within the archive.
+
+    Args:
+        base_path: Root directory for all file lookups.
+        index_path: Path for the SQLite index file used to cache tar member
+            offsets. If ``None``, a default ``index.db`` file is created in
+            ``base_path``.
+    """
+
+    def __init__(self, base_path: str | Path, *, index_path: str | Path | None = None) -> None:
+        self._base_path = Path(base_path)
+        self._index_path = Path(index_path) if index_path else self._base_path / "index.db"
+        self._db: sqlite3.Connection | None = None
+
+    def _get_db(self) -> sqlite3.Connection:
+        """Return the SQLite connection, creating it and the schema lazily."""
+        if self._db is None:
+            self._db = sqlite3.connect(str(self._index_path), check_same_thread=False)
+            self._db.execute(
+                "CREATE TABLE IF NOT EXISTS tar_index ("
+                "  tar_name TEXT NOT NULL,"
+                "  member_name TEXT NOT NULL,"
+                "  offset INTEGER NOT NULL,"
+                "  size INTEGER NOT NULL,"
+                "  PRIMARY KEY (tar_name, member_name)"
+                ")"
+            )
+            self._db.commit()
+        return self._db
+
+    def _is_indexed(self, tar_name: str) -> bool:
+        """Check whether a tar archive has already been indexed."""
+        db = self._get_db()
+        row = db.execute(
+            "SELECT 1 FROM tar_index WHERE tar_name = ? LIMIT 1", (tar_name,)
+        ).fetchone()
+        return row is not None
+
+    def _index_tar(self, tar_path: Path, tar_name: str) -> None:
+        """Build the SQLite index for a tar archive's members."""
+        db = self._get_db()
+        with tarfile.open(tar_path, "r") as tf:
+            for member in tf.getmembers():
+                if member.isfile():
+                    db.execute(
+                        "INSERT OR REPLACE INTO tar_index (tar_name, member_name, offset, size) "
+                        "VALUES (?, ?, ?, ?)",
+                        (tar_name, member.name, member.offset_data, member.size),
+                    )
+        db.commit()
+
+    def _load_from_tar(self, tar_path: Path, member_name: str) -> bytes | None:
+        """Load a single member from a tar archive using the index if available."""
+        tar_name = tar_path.name
+
+        if not self._is_indexed(tar_name):
+            self._index_tar(tar_path, tar_name)
+
+        db = self._get_db()
+        row = db.execute(
+            "SELECT offset, size FROM tar_index WHERE tar_name = ? AND member_name = ?",
+            (tar_name, member_name),
+        ).fetchone()
+
+        if row is None:
+            return None
+
+        offset, size = row
+        with open(tar_path, "rb") as f:
+            f.seek(offset)
+            return f.read(size)
+
+    def _load_from_directory(self, rel_path: str) -> bytes | None:
+        """Load a file from the base directory by relative path."""
+        full_path = self._base_path / rel_path
+        if not full_path.is_file():
+            return None
+        return full_path.read_bytes()
+
+    def _parse_path(self, path: str) -> tuple[Path | None, str | None, str]:
+        """Parse a path into (tar_path, member_name, raw_path).
+
+        Returns (tar_path, member_name, raw_path) where tar_path is set if the
+        path refers to a tar member, otherwise both tar_path and member_name are
+        None and raw_path is used for directory loading.
+        """
+        parts = path.split("/", 1)
+        if len(parts) == 2 and parts[0].endswith(".tar"):
+            tar_path = self._base_path / parts[0]
+            if tar_path.is_file():
+                return tar_path, parts[1], path
+        return None, None, path
+
+    def _sync_load_file(self, path: str) -> bytes | None:
+        """Synchronous file loading (called from asyncio.to_thread)."""
+        tar_path, member_name, raw_path = self._parse_path(path)
+        if tar_path is not None and member_name is not None:
+            return self._load_from_tar(tar_path, member_name)
+        return self._load_from_directory(raw_path)
+
+    def _sync_load_files(self, paths: list[str]) -> dict[str, bytes]:
+        """Synchronous batch file loading, grouping tar reads by archive."""
+        results: dict[str, bytes] = {}
+
+        # Group paths by storage unit
+        tar_groups: dict[str, list[tuple[str, str]]] = defaultdict(list)
+        dir_paths: list[str] = []
+
+        for path in paths:
+            tar_path, member_name, raw_path = self._parse_path(path)
+            if tar_path is not None and member_name is not None:
+                tar_groups[str(tar_path)].append((path, member_name))
+            else:
+                dir_paths.append(raw_path)
+
+        # Load from tar archives (grouped by archive for efficiency)
+        for tar_path_str, members in tar_groups.items():
+            tar_path_obj = Path(tar_path_str)
+            tar_name = tar_path_obj.name
+
+            if not self._is_indexed(tar_name):
+                self._index_tar(tar_path_obj, tar_name)
+
+            for orig_path, member_name in members:
+                data = self._load_from_tar(tar_path_obj, member_name)
+                if data is not None:
+                    results[orig_path] = data
+
+        # Load from directories
+        for path in dir_paths:
+            data = self._load_from_directory(path)
+            if data is not None:
+                results[path] = data
+
+        return results
+
+    def _sync_list_files(self, pattern: str) -> list[str]:
+        """Synchronous file listing by glob pattern."""
+        return [
+            str(p.relative_to(self._base_path))
+            for p in self._base_path.glob(pattern)
+            if p.is_file()
+        ]
+
+    async def load_file(self, path: str) -> bytes | None:
+        """Load a single file by relative path.
+
+        For tar members, use ``"archive.tar/member_name.json"`` format.
+
+        Args:
+            path: Relative path from the base directory.
+
+        Returns:
+            File contents as bytes, or ``None`` if the file does not exist.
+        """
+        return await asyncio.to_thread(self._sync_load_file, path)
+
+    async def load_files(self, paths: list[str]) -> dict[str, bytes]:
+        """Batch-load multiple files, grouping tar reads by archive.
+
+        Args:
+            paths: List of relative paths.
+
+        Returns:
+            Dict mapping each successfully loaded path to its bytes content.
+        """
+        return await asyncio.to_thread(self._sync_load_files, paths)
+
+    async def list_files(self, pattern: str = "*") -> list[str]:
+        """List files matching a glob pattern relative to the base directory.
+
+        Args:
+            pattern: Glob pattern (default ``"*"``).
+
+        Returns:
+            List of relative file paths matching the pattern.
+        """
+        return await asyncio.to_thread(self._sync_list_files, pattern)
+
+    async def close(self) -> None:
+        """Close the SQLite index connection, if one was opened."""
+        if self._db is not None:
+            self._db.close()
+            self._db = None

--- a/src/wxyc_catalog/sources/archive.py
+++ b/src/wxyc_catalog/sources/archive.py
@@ -1,0 +1,7 @@
+"""File loading from directories and tar archives with SQLite index caching."""
+
+from __future__ import annotations
+
+
+class ArchiveSource:
+    """Placeholder — implementation pending."""

--- a/src/wxyc_catalog/sources/http.py
+++ b/src/wxyc_catalog/sources/http.py
@@ -1,0 +1,7 @@
+"""Async HTTP client with rate limiting and exponential backoff retry."""
+
+from __future__ import annotations
+
+
+class HttpSource:
+    """Placeholder — implementation pending."""

--- a/src/wxyc_catalog/sources/http.py
+++ b/src/wxyc_catalog/sources/http.py
@@ -1,7 +1,149 @@
-"""Async HTTP client with rate limiting and exponential backoff retry."""
+"""Async HTTP client with rate limiting and exponential backoff retry.
+
+Provides:
+- Shared httpx.AsyncClient session (reused across requests)
+- Configurable rate limiter (token-bucket via asyncio primitives)
+- Exponential backoff retry on 429 (Too Many Requests) and 403 (Forbidden)
+- Request/response logging
+- Configurable timeout
+"""
 
 from __future__ import annotations
 
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+RETRYABLE_STATUS_CODES = {429, 403}
+
 
 class HttpSource:
-    """Placeholder — implementation pending."""
+    """Async HTTP client with rate limiting and exponential backoff retry.
+
+    Args:
+        base_url: Base URL for all requests. If ``None``, full URLs must be provided.
+        rate_limit: Maximum number of requests per ``rate_window``.
+        rate_window: Time window in seconds for the rate limit.
+        max_retries: Maximum number of retries on retryable status codes.
+        timeout: Request timeout in seconds.
+        headers: Extra headers to include with every request.
+    """
+
+    def __init__(
+        self,
+        base_url: str | None = None,
+        *,
+        rate_limit: float = 60.0,
+        rate_window: float = 60.0,
+        max_retries: int = 3,
+        timeout: float = 30.0,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self._base_url = base_url
+        self._rate_limit = rate_limit
+        self._rate_window = rate_window
+        self._max_retries = max_retries
+        self._timeout = timeout
+        self._headers = headers or {}
+        self._client: httpx.AsyncClient | None = None
+
+        # Token-bucket rate limiter state
+        self._interval = rate_window / rate_limit if rate_limit > 0 else 0.0
+        self._last_request_time: float | None = None
+        self._rate_lock = asyncio.Lock()
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Return the shared client, creating it lazily."""
+        if self._client is None or self._client.is_closed:
+            kwargs: dict[str, Any] = {
+                "timeout": self._timeout,
+                "headers": self._headers,
+            }
+            if self._base_url:
+                kwargs["base_url"] = self._base_url
+            self._client = httpx.AsyncClient(**kwargs)
+        return self._client
+
+    async def _wait_for_rate_limit(self) -> None:
+        """Wait until the rate limiter allows the next request."""
+        if self._interval <= 0:
+            return
+
+        async with self._rate_lock:
+            now = asyncio.get_event_loop().time()
+            if self._last_request_time is not None:
+                elapsed = now - self._last_request_time
+                wait = self._interval - elapsed
+                if wait > 0:
+                    await asyncio.sleep(wait)
+            self._last_request_time = asyncio.get_event_loop().time()
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response | None:
+        """Execute an HTTP request with rate limiting and retry.
+
+        Returns the response on success, or ``None`` if all retries are exhausted.
+        """
+        client = self._get_client()
+
+        for attempt in range(1 + self._max_retries):
+            await self._wait_for_rate_limit()
+            try:
+                response = await getattr(client, method)(path, **kwargs)
+            except httpx.HTTPError:
+                logger.warning("HTTP %s %s failed", method.upper(), path, exc_info=True)
+                return None
+
+            if response.status_code not in RETRYABLE_STATUS_CODES:
+                return response
+
+            if attempt < self._max_retries:
+                delay = 2**attempt * 0.1  # 0.1s, 0.2s, 0.4s, ...
+                logger.info(
+                    "Retryable %d from %s %s, retrying in %.1fs (attempt %d/%d)",
+                    response.status_code,
+                    method.upper(),
+                    path,
+                    delay,
+                    attempt + 1,
+                    self._max_retries,
+                )
+                await asyncio.sleep(delay)
+
+        logger.warning(
+            "Exhausted %d retries for %s %s", self._max_retries, method.upper(), path
+        )
+        return None
+
+    async def get(self, path: str, **kwargs: Any) -> httpx.Response | None:
+        """Send a GET request.
+
+        Args:
+            path: URL path (appended to ``base_url``) or full URL.
+            **kwargs: Extra arguments passed to ``httpx.AsyncClient.get()``.
+
+        Returns:
+            The response, or ``None`` if the request failed or retries were exhausted.
+        """
+        return await self._request("get", path, **kwargs)
+
+    async def post(self, path: str, **kwargs: Any) -> httpx.Response | None:
+        """Send a POST request.
+
+        Args:
+            path: URL path (appended to ``base_url``) or full URL.
+            **kwargs: Extra arguments passed to ``httpx.AsyncClient.post()``.
+
+        Returns:
+            The response, or ``None`` if the request failed or retries were exhausted.
+        """
+        return await self._request("post", path, **kwargs)
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client, if one was created."""
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None

--- a/src/wxyc_catalog/sources/http.py
+++ b/src/wxyc_catalog/sources/http.py
@@ -82,7 +82,9 @@ class HttpSource:
                     await asyncio.sleep(wait)
             self._last_request_time = asyncio.get_event_loop().time()
 
-    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response | None:
+    async def _request(
+        self, method: str, path: str, **kwargs: Any
+    ) -> httpx.Response | None:
         """Execute an HTTP request with rate limiting and retry.
 
         Returns the response on success, or ``None`` if all retries are exhausted.

--- a/src/wxyc_catalog/sources/pg.py
+++ b/src/wxyc_catalog/sources/pg.py
@@ -31,7 +31,9 @@ class PgSource:
         max_size: Maximum number of connections in the pool.
     """
 
-    def __init__(self, dsn: str | None, *, min_size: int = 1, max_size: int = 5) -> None:
+    def __init__(
+        self, dsn: str | None, *, min_size: int = 1, max_size: int = 5
+    ) -> None:
         self._dsn = dsn
         self._min_size = min_size
         self._max_size = max_size
@@ -56,7 +58,9 @@ class PgSource:
             )
             return self._pool
         except Exception:
-            logger.warning("Failed to connect to PostgreSQL at %s", self._dsn, exc_info=True)
+            logger.warning(
+                "Failed to connect to PostgreSQL at %s", self._dsn, exc_info=True
+            )
             self._pool = None
             return None
 

--- a/src/wxyc_catalog/sources/pg.py
+++ b/src/wxyc_catalog/sources/pg.py
@@ -1,0 +1,136 @@
+"""Async PostgreSQL connection pool with lazy connect and graceful degradation.
+
+Provides:
+- Lazy connection: pool created on first query, not at init time
+- Graceful None: returns None instead of raising on connection failure
+- Reconnect: automatically reconnects if pool is closed
+- Batch helpers: fetch_with_unnest()
+- Configurable pool size via min_size/max_size
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+
+class PgSource:
+    """Async PostgreSQL connection pool with lazy connect and graceful degradation.
+
+    All query methods return ``None`` on connection failure instead of raising,
+    letting callers implement fallback logic (e.g., falling back to an HTTP API
+    when a PostgreSQL cache is unavailable).
+
+    Args:
+        dsn: PostgreSQL connection string, or ``None`` to disable all queries.
+        min_size: Minimum number of connections in the pool.
+        max_size: Maximum number of connections in the pool.
+    """
+
+    def __init__(self, dsn: str | None, *, min_size: int = 1, max_size: int = 5) -> None:
+        self._dsn = dsn
+        self._min_size = min_size
+        self._max_size = max_size
+        self._pool: asyncpg.Pool | None = None
+
+    async def get_pool(self) -> asyncpg.Pool | None:
+        """Return the connection pool, creating it lazily on first call.
+
+        Returns ``None`` if ``dsn`` was not provided or if connecting fails.
+        """
+        if self._dsn is None:
+            return None
+
+        if self._pool is not None and not self._pool.is_closing():
+            return self._pool
+
+        try:
+            self._pool = await asyncpg.create_pool(
+                self._dsn,
+                min_size=self._min_size,
+                max_size=self._max_size,
+            )
+            return self._pool
+        except Exception:
+            logger.warning("Failed to connect to PostgreSQL at %s", self._dsn, exc_info=True)
+            self._pool = None
+            return None
+
+    async def fetchall(self, query: str, *args: Any) -> list[asyncpg.Record] | None:
+        """Execute a query and return all rows, or ``None`` on failure.
+
+        Args:
+            query: SQL query string with ``$1``, ``$2``, ... placeholders.
+            *args: Positional parameters for the query.
+        """
+        pool = await self.get_pool()
+        if pool is None:
+            return None
+        try:
+            return await pool.fetch(query, *args)
+        except Exception:
+            logger.warning("Query failed: %s", query, exc_info=True)
+            return None
+
+    async def fetchone(self, query: str, *args: Any) -> asyncpg.Record | None:
+        """Execute a query and return the first row, or ``None`` on failure.
+
+        Args:
+            query: SQL query string with ``$1``, ``$2``, ... placeholders.
+            *args: Positional parameters for the query.
+        """
+        pool = await self.get_pool()
+        if pool is None:
+            return None
+        try:
+            return await pool.fetchrow(query, *args)
+        except Exception:
+            logger.warning("Query failed: %s", query, exc_info=True)
+            return None
+
+    async def execute(self, query: str, *args: Any) -> str | None:
+        """Execute a query and return the status string, or ``None`` on failure.
+
+        Args:
+            query: SQL query string with ``$1``, ``$2``, ... placeholders.
+            *args: Positional parameters for the query.
+        """
+        pool = await self.get_pool()
+        if pool is None:
+            return None
+        try:
+            return await pool.execute(query, *args)
+        except Exception:
+            logger.warning("Query failed: %s", query, exc_info=True)
+            return None
+
+    async def fetch_with_unnest(
+        self, query: str, values: list, type_: str = "text"
+    ) -> list[asyncpg.Record] | None:
+        """Execute a query passing *values* as an unnested array parameter.
+
+        Useful for ``WHERE col = ANY($1)`` patterns where ``$1`` is a list.
+
+        Args:
+            query: SQL query with a ``$1`` placeholder for the array.
+            values: List of values to pass as the array parameter.
+            type_: PostgreSQL type name for the array elements (default ``"text"``).
+        """
+        pool = await self.get_pool()
+        if pool is None:
+            return None
+        try:
+            return await pool.fetch(query, values)
+        except Exception:
+            logger.warning("Query failed: %s", query, exc_info=True)
+            return None
+
+    async def close(self) -> None:
+        """Close the connection pool, if one was created."""
+        if self._pool is not None:
+            await self._pool.close()
+            self._pool = None

--- a/src/wxyc_catalog/sources/sparql.py
+++ b/src/wxyc_catalog/sources/sparql.py
@@ -1,9 +1,144 @@
-"""SPARQL query executor with result parsing, QID validation, and batch splitting."""
+"""SPARQL query executor with result parsing, QID validation, and batch splitting.
+
+Extends :class:`HttpSource` with:
+- SPARQL query execution via GET with ``Accept: application/sparql-results+json``
+- Result binding extraction from the standard SPARQL JSON response format
+- QID format validation (Q followed by digits)
+- Batch splitting: large QID lists are chunked into VALUES clauses
+- User-Agent header (required by Wikidata)
+"""
 
 from __future__ import annotations
 
+import logging
+import re
+from typing import Any
+
 from wxyc_catalog.sources.http import HttpSource
+
+logger = logging.getLogger(__name__)
+
+_QID_RE = re.compile(r"^Q\d+$")
 
 
 class SparqlSource(HttpSource):
-    """Placeholder — implementation pending."""
+    """SPARQL query executor with result parsing, QID validation, and batch splitting.
+
+    Args:
+        sparql_endpoint: SPARQL endpoint URL.
+        user_agent: User-Agent header value (required by Wikidata).
+        batch_size: Maximum number of QIDs per VALUES clause in batched queries.
+        rate_limit: Requests per ``rate_window`` (default: 1 req/sec for Wikidata).
+        rate_window: Time window in seconds for the rate limit.
+        **kwargs: Additional arguments passed to :class:`HttpSource`.
+    """
+
+    def __init__(
+        self,
+        sparql_endpoint: str = "https://query.wikidata.org/sparql",
+        *,
+        user_agent: str = "WXYCSemanticIndex/0.1 (https://wxyc.org; engineering@wxyc.org)",
+        batch_size: int = 50,
+        rate_limit: float = 1.0,
+        rate_window: float = 1.0,
+        **kwargs: Any,
+    ) -> None:
+        headers = kwargs.pop("headers", None) or {}
+        headers.setdefault("User-Agent", user_agent)
+        headers.setdefault("Accept", "application/sparql-results+json")
+        super().__init__(
+            base_url=sparql_endpoint,
+            rate_limit=rate_limit,
+            rate_window=rate_window,
+            headers=headers,
+            **kwargs,
+        )
+        self._batch_size = batch_size
+
+    async def query(self, sparql: str) -> list[dict]:
+        """Execute a SPARQL query and return the result bindings.
+
+        Args:
+            sparql: SPARQL query string.
+
+        Returns:
+            List of binding dicts from the SPARQL JSON response, or an empty
+            list on failure.
+        """
+        response = await self.get("", params={"query": sparql})
+        if response is None:
+            return []
+        try:
+            data = response.json()
+            return data["results"]["bindings"]
+        except Exception:
+            logger.warning("Failed to parse SPARQL response", exc_info=True)
+            return []
+
+    async def query_batched(
+        self, sparql_template: str, qids: list[str], placeholder: str = "{values}"
+    ) -> list[dict]:
+        """Execute a SPARQL query in batches, splitting QIDs into VALUES clauses.
+
+        Invalid QIDs are filtered out before batching.
+
+        Args:
+            sparql_template: SPARQL query template with a ``{values}`` placeholder.
+            qids: List of Wikidata QIDs to query.
+            placeholder: Placeholder string in the template (default ``"{values}"``).
+
+        Returns:
+            Combined list of bindings from all batch results.
+        """
+        valid = self.validate_qids(qids)
+        if not valid:
+            return []
+
+        all_bindings: list[dict] = []
+        for i in range(0, len(valid), self._batch_size):
+            batch = valid[i : i + self._batch_size]
+            values_clause = " ".join(f"wd:{qid}" for qid in batch)
+            sparql = sparql_template.replace(placeholder, values_clause)
+            bindings = await self.query(sparql)
+            all_bindings.extend(bindings)
+
+        return all_bindings
+
+    def validate_qids(self, qids: list[str]) -> list[str]:
+        """Filter a list of strings to only valid Wikidata QIDs (``Q`` followed by digits).
+
+        Args:
+            qids: List of candidate QID strings.
+
+        Returns:
+            Filtered list containing only valid QIDs, preserving order.
+        """
+        return [qid for qid in qids if _QID_RE.match(qid)]
+
+    @staticmethod
+    def extract_qid(uri: str) -> str:
+        """Extract a QID from a Wikidata entity URI or bare QID string.
+
+        Args:
+            uri: A string like ``"http://www.wikidata.org/entity/Q2774"`` or ``"Q2774"``.
+
+        Returns:
+            The QID portion (e.g., ``"Q2774"``).
+        """
+        return uri.rsplit("/", 1)[-1]
+
+    @staticmethod
+    def binding_value(binding: dict, key: str) -> str | None:
+        """Extract the ``value`` field from a SPARQL binding, or ``None`` if absent.
+
+        Args:
+            binding: A single binding dict from a SPARQL response.
+            key: The variable name to look up.
+
+        Returns:
+            The string value, or ``None`` if the key is not present.
+        """
+        entry = binding.get(key)
+        if entry is None:
+            return None
+        return entry.get("value")

--- a/src/wxyc_catalog/sources/sparql.py
+++ b/src/wxyc_catalog/sources/sparql.py
@@ -1,0 +1,9 @@
+"""SPARQL query executor with result parsing, QID validation, and batch splitting."""
+
+from __future__ import annotations
+
+from wxyc_catalog.sources.http import HttpSource
+
+
+class SparqlSource(HttpSource):
+    """Placeholder — implementation pending."""

--- a/tests/test_archive_source.py
+++ b/tests/test_archive_source.py
@@ -2,8 +2,6 @@ import asyncio
 import io
 import tarfile
 
-import pytest
-
 from wxyc_catalog.sources.archive import ArchiveSource
 
 

--- a/tests/test_archive_source.py
+++ b/tests/test_archive_source.py
@@ -1,0 +1,153 @@
+import asyncio
+import io
+import tarfile
+
+import pytest
+
+from wxyc_catalog.sources.archive import ArchiveSource
+
+
+class TestArchiveSourceDirectory:
+    """ArchiveSource should load files from a directory."""
+
+    async def test_load_file_from_directory(self, tmp_path):
+        """Should load a file by relative path from the base directory."""
+        (tmp_path / "data").mkdir()
+        (tmp_path / "data" / "file.json").write_text('{"key": "value"}')
+
+        source = ArchiveSource(tmp_path)
+        content = await source.load_file("data/file.json")
+        assert content is not None
+        assert b'"key"' in content
+        await source.close()
+
+    async def test_load_missing_file_returns_none(self, tmp_path):
+        """Should return None for non-existent files."""
+        source = ArchiveSource(tmp_path)
+        content = await source.load_file("nonexistent.json")
+        assert content is None
+        await source.close()
+
+    async def test_list_files(self, tmp_path):
+        """Should list files matching a glob pattern."""
+        (tmp_path / "a.json").write_text("{}")
+        (tmp_path / "b.json").write_text("{}")
+        (tmp_path / "c.txt").write_text("")
+
+        source = ArchiveSource(tmp_path)
+        json_files = await source.list_files("*.json")
+        assert len(json_files) == 2
+        assert all(f.endswith(".json") for f in json_files)
+        await source.close()
+
+    async def test_load_files_batch(self, tmp_path):
+        """Should batch-load multiple files from a directory."""
+        for i in range(3):
+            (tmp_path / f"file_{i}.json").write_text(f'{{"id": {i}}}')
+
+        source = ArchiveSource(tmp_path)
+        results = await source.load_files([f"file_{i}.json" for i in range(3)])
+        assert len(results) == 3
+        await source.close()
+
+
+class TestArchiveSourceTar:
+    """ArchiveSource should load files from tar archives."""
+
+    async def test_load_file_from_tar(self, tmp_path):
+        """Should load a file from a tar archive."""
+        tar_path = tmp_path / "archive.tar"
+        content = b'{"feature": [1.0, 2.0, 3.0]}'
+        with tarfile.open(tar_path, "w") as tf:
+            info = tarfile.TarInfo(name="Q12345.json")
+            info.size = len(content)
+            tf.addfile(info, io.BytesIO(content))
+
+        source = ArchiveSource(tmp_path)
+        loaded = await source.load_file("archive.tar/Q12345.json")
+        assert loaded is not None
+        assert b'"feature"' in loaded
+        await source.close()
+
+    async def test_load_missing_member_returns_none(self, tmp_path):
+        """Should return None for non-existent tar members."""
+        tar_path = tmp_path / "archive.tar"
+        with tarfile.open(tar_path, "w") as tf:
+            data = b"{}"
+            info = tarfile.TarInfo(name="exists.json")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+
+        source = ArchiveSource(tmp_path)
+        loaded = await source.load_file("archive.tar/missing.json")
+        assert loaded is None
+        await source.close()
+
+    async def test_batch_load_from_tar(self, tmp_path):
+        """Should batch-load multiple files from the same tar efficiently."""
+        tar_path = tmp_path / "archive.tar"
+        with tarfile.open(tar_path, "w") as tf:
+            for i in range(5):
+                data = f'{{"id": {i}}}'.encode()
+                info = tarfile.TarInfo(name=f"file_{i}.json")
+                info.size = len(data)
+                tf.addfile(info, io.BytesIO(data))
+
+        source = ArchiveSource(tmp_path)
+        paths = [f"archive.tar/file_{i}.json" for i in range(5)]
+        results = await source.load_files(paths)
+        assert len(results) == 5
+        await source.close()
+
+
+class TestArchiveSourceSqliteIndex:
+    """ArchiveSource should persist a SQLite index for tar member lookup."""
+
+    async def test_creates_index_on_first_access(self, tmp_path):
+        """SQLite index should be created on first tar access."""
+        tar_path = tmp_path / "archive.tar"
+        with tarfile.open(tar_path, "w") as tf:
+            data = b"{}"
+            info = tarfile.TarInfo(name="test.json")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+
+        index_path = tmp_path / "index.db"
+        source = ArchiveSource(tmp_path, index_path=index_path)
+        await source.load_file("archive.tar/test.json")
+        assert index_path.exists()
+        await source.close()
+
+    async def test_reuses_existing_index(self, tmp_path):
+        """Second access should use the existing SQLite index, not re-scan."""
+        tar_path = tmp_path / "archive.tar"
+        with tarfile.open(tar_path, "w") as tf:
+            data = b"{}"
+            info = tarfile.TarInfo(name="test.json")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+
+        index_path = tmp_path / "index.db"
+        # First access: build index
+        source1 = ArchiveSource(tmp_path, index_path=index_path)
+        await source1.load_file("archive.tar/test.json")
+        mtime1 = index_path.stat().st_mtime
+        await source1.close()
+
+        await asyncio.sleep(0.1)
+
+        # Second access: reuse index (mtime should not change)
+        source2 = ArchiveSource(tmp_path, index_path=index_path)
+        await source2.load_file("archive.tar/test.json")
+        mtime2 = index_path.stat().st_mtime
+        assert mtime1 == mtime2
+        await source2.close()
+
+
+class TestArchiveSourceClose:
+    """ArchiveSource close() should clean up resources."""
+
+    async def test_close_is_safe(self, tmp_path):
+        """close() should be safe to call even without any file access."""
+        source = ArchiveSource(tmp_path)
+        await source.close()  # should not raise

--- a/tests/test_http_source.py
+++ b/tests/test_http_source.py
@@ -1,0 +1,118 @@
+import time
+
+import pytest
+
+from wxyc_catalog.sources.http import HttpSource
+
+
+class TestHttpSourceRateLimiting:
+    """HttpSource should respect configured rate limits."""
+
+    async def test_rate_limit_delays_requests(self, httpx_mock):
+        """Consecutive requests should be delayed to respect rate limit."""
+        httpx_mock.add_response(status_code=200)
+        httpx_mock.add_response(status_code=200)
+
+        # 1 request per second rate limit
+        source = HttpSource(
+            base_url="https://example.com",
+            rate_limit=1.0,
+            rate_window=1.0,
+        )
+        start = time.monotonic()
+        await source.get("/a")
+        await source.get("/b")
+        elapsed = time.monotonic() - start
+        # Second request should be delayed by ~1 second
+        assert elapsed >= 0.9
+        await source.close()
+
+
+class TestHttpSourceRetry:
+    """HttpSource should retry on 429 and 403 with exponential backoff."""
+
+    async def test_retry_on_429(self, httpx_mock):
+        """Should retry on 429 Too Many Requests."""
+        httpx_mock.add_response(status_code=429)
+        httpx_mock.add_response(status_code=200, json={"ok": True})
+
+        source = HttpSource(
+            base_url="https://example.com",
+            rate_limit=1000,
+            max_retries=3,
+        )
+        response = await source.get("/test")
+        assert response is not None
+        assert response.status_code == 200
+        await source.close()
+
+    async def test_retry_on_403(self, httpx_mock):
+        """Should retry on 403 Forbidden (Wikidata rate limit)."""
+        httpx_mock.add_response(status_code=403)
+        httpx_mock.add_response(status_code=200, json={"ok": True})
+
+        source = HttpSource(
+            base_url="https://example.com",
+            rate_limit=1000,
+            max_retries=3,
+        )
+        response = await source.get("/test")
+        assert response is not None
+        assert response.status_code == 200
+        await source.close()
+
+    async def test_returns_none_after_max_retries(self, httpx_mock):
+        """Should return None after exhausting all retries."""
+        for _ in range(4):
+            httpx_mock.add_response(status_code=429)
+
+        source = HttpSource(
+            base_url="https://example.com",
+            rate_limit=1000,
+            max_retries=3,
+        )
+        response = await source.get("/test")
+        assert response is None
+        await source.close()
+
+    async def test_no_retry_on_non_retryable_status(self, httpx_mock):
+        """Should not retry on 404, 500, or other non-retryable codes."""
+        httpx_mock.add_response(status_code=404)
+
+        source = HttpSource(
+            base_url="https://example.com",
+            rate_limit=1000,
+            max_retries=3,
+        )
+        response = await source.get("/test")
+        assert response is not None
+        assert response.status_code == 404
+        await source.close()
+
+
+class TestHttpSourcePost:
+    """HttpSource should support POST requests."""
+
+    async def test_post_request(self, httpx_mock):
+        """post() should send a POST request."""
+        httpx_mock.add_response(status_code=200, json={"created": True})
+
+        source = HttpSource(
+            base_url="https://example.com",
+            rate_limit=1000,
+        )
+        response = await source.post("/items", json={"name": "test"})
+        assert response is not None
+        assert response.status_code == 200
+        request = httpx_mock.get_requests()[0]
+        assert request.method == "POST"
+        await source.close()
+
+
+class TestHttpSourceClose:
+    """HttpSource close() should clean up the client."""
+
+    async def test_close_is_safe_without_requests(self):
+        """close() should be safe to call even if no requests were made."""
+        source = HttpSource(base_url="https://example.com", rate_limit=1000)
+        await source.close()  # should not raise

--- a/tests/test_http_source.py
+++ b/tests/test_http_source.py
@@ -1,7 +1,5 @@
 import time
 
-import pytest
-
 from wxyc_catalog.sources.http import HttpSource
 
 

--- a/tests/test_pg_source.py
+++ b/tests/test_pg_source.py
@@ -1,5 +1,4 @@
-import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from wxyc_catalog.sources.pg import PgSource
 
@@ -34,7 +33,11 @@ class TestPgSourceGracefulNone:
 
     async def test_connection_failure_returns_none(self):
         """When connection fails, queries should return None."""
-        with patch("asyncpg.create_pool", new_callable=AsyncMock, side_effect=Exception("refused")):
+        with patch(
+            "asyncpg.create_pool",
+            new_callable=AsyncMock,
+            side_effect=Exception("refused"),
+        ):
             source = PgSource("postgresql://bad-host/db")
             result = await source.fetchall("SELECT 1")
             assert result is None

--- a/tests/test_pg_source.py
+++ b/tests/test_pg_source.py
@@ -1,0 +1,143 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from wxyc_catalog.sources.pg import PgSource
+
+
+class TestPgSourceLazyConnect:
+    """PgSource should create the pool on first query, not at init time."""
+
+    async def test_no_pool_at_init(self):
+        """Pool should not be created during __init__."""
+        source = PgSource("postgresql://localhost/test")
+        assert source._pool is None
+
+    async def test_pool_created_on_first_query(self):
+        """Pool should be created when first query is executed."""
+        with patch("asyncpg.create_pool", new_callable=AsyncMock) as mock_create:
+            mock_pool = AsyncMock()
+            mock_pool.fetch = AsyncMock(return_value=[])
+            mock_create.return_value = mock_pool
+            source = PgSource("postgresql://localhost/test")
+            await source.fetchall("SELECT 1")
+            mock_create.assert_awaited_once()
+
+
+class TestPgSourceGracefulNone:
+    """PgSource should return None on connection failure, not raise."""
+
+    async def test_none_dsn_returns_none(self):
+        """When dsn is None, all queries should return None."""
+        source = PgSource(None)
+        result = await source.fetchall("SELECT 1")
+        assert result is None
+
+    async def test_connection_failure_returns_none(self):
+        """When connection fails, queries should return None."""
+        with patch("asyncpg.create_pool", new_callable=AsyncMock, side_effect=Exception("refused")):
+            source = PgSource("postgresql://bad-host/db")
+            result = await source.fetchall("SELECT 1")
+            assert result is None
+
+    async def test_fetchone_none_dsn_returns_none(self):
+        """fetchone() should also return None when dsn is None."""
+        source = PgSource(None)
+        result = await source.fetchone("SELECT 1")
+        assert result is None
+
+    async def test_execute_none_dsn_returns_none(self):
+        """execute() should also return None when dsn is None."""
+        source = PgSource(None)
+        result = await source.execute("SELECT 1")
+        assert result is None
+
+    async def test_query_after_pool_close_reconnects_or_returns_none(self):
+        """After pool is closed, queries should attempt reconnect or return None."""
+        with patch("asyncpg.create_pool", new_callable=AsyncMock) as mock_create:
+            mock_pool = AsyncMock()
+            mock_pool.fetch = AsyncMock(side_effect=Exception("pool closed"))
+            mock_pool.is_closing = MagicMock(return_value=True)
+            mock_create.return_value = mock_pool
+            source = PgSource("postgresql://localhost/test")
+            result = await source.fetchall("SELECT 1")
+            assert result is None
+
+
+class TestPgSourceReconnect:
+    """PgSource should reconnect when the pool is closed or broken."""
+
+    async def test_reconnects_after_closed_pool(self):
+        """A new pool should be created after the old one is closed."""
+        call_count = 0
+
+        async def create_pool_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_pool = AsyncMock()
+            if call_count == 1:
+                mock_pool.fetch = AsyncMock(side_effect=Exception("closed"))
+                mock_pool.is_closing = MagicMock(return_value=True)
+            else:
+                mock_pool.fetch = AsyncMock(return_value=[{"id": 1}])
+                mock_pool.is_closing = MagicMock(return_value=False)
+            return mock_pool
+
+        with patch(
+            "asyncpg.create_pool",
+            new_callable=AsyncMock,
+            side_effect=create_pool_side_effect,
+        ):
+            source = PgSource("postgresql://localhost/test")
+            # First call triggers pool creation, pool is "closed"
+            await source.fetchall("SELECT 1")
+            # Force reconnect by resetting internal pool
+            source._pool = None
+            result = await source.fetchall("SELECT 1")
+            assert result is not None
+
+
+class TestPgSourceBatchHelpers:
+    """PgSource batch query helpers."""
+
+    async def test_fetch_with_unnest(self):
+        """fetch_with_unnest should pass values as unnest parameter."""
+        with patch("asyncpg.create_pool", new_callable=AsyncMock) as mock_create:
+            mock_pool = AsyncMock()
+            mock_pool.fetch = AsyncMock(return_value=[])
+            mock_create.return_value = mock_pool
+            source = PgSource("postgresql://localhost/test")
+            await source.fetch_with_unnest(
+                "SELECT * FROM t WHERE name = ANY($1)",
+                ["alice", "bob"],
+            )
+            mock_pool.fetch.assert_awaited_once()
+
+    async def test_fetch_with_unnest_none_dsn(self):
+        """fetch_with_unnest should return None when dsn is None."""
+        source = PgSource(None)
+        result = await source.fetch_with_unnest(
+            "SELECT * FROM t WHERE name = ANY($1)",
+            ["alice", "bob"],
+        )
+        assert result is None
+
+
+class TestPgSourceClose:
+    """PgSource close() should clean up resources."""
+
+    async def test_close_pool(self):
+        """close() should close the underlying pool."""
+        with patch("asyncpg.create_pool", new_callable=AsyncMock) as mock_create:
+            mock_pool = AsyncMock()
+            mock_pool.fetch = AsyncMock(return_value=[])
+            mock_pool.close = AsyncMock()
+            mock_create.return_value = mock_pool
+            source = PgSource("postgresql://localhost/test")
+            await source.fetchall("SELECT 1")
+            await source.close()
+            mock_pool.close.assert_awaited_once()
+
+    async def test_close_no_pool(self):
+        """close() should be safe to call when no pool was created."""
+        source = PgSource("postgresql://localhost/test")
+        await source.close()  # should not raise

--- a/tests/test_sparql_source.py
+++ b/tests/test_sparql_source.py
@@ -1,5 +1,3 @@
-import pytest
-
 from wxyc_catalog.sources.sparql import SparqlSource
 
 
@@ -12,7 +10,10 @@ class TestSparqlSourceQueryExecution:
             "results": {
                 "bindings": [
                     {
-                        "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q2774"},
+                        "item": {
+                            "type": "uri",
+                            "value": "http://www.wikidata.org/entity/Q2774",
+                        },
                         "itemLabel": {"type": "literal", "value": "Autechre"},
                     },
                 ]
@@ -24,7 +25,9 @@ class TestSparqlSourceQueryExecution:
             sparql_endpoint="https://query.wikidata.org/sparql",
             rate_limit=1000,
         )
-        bindings = await source.query("SELECT ?item ?itemLabel WHERE { ?item wdt:P1953 '14' }")
+        bindings = await source.query(
+            "SELECT ?item ?itemLabel WHERE { ?item wdt:P1953 '14' }"
+        )
         assert len(bindings) == 1
         assert bindings[0]["item"]["value"] == "http://www.wikidata.org/entity/Q2774"
         await source.close()
@@ -70,14 +73,21 @@ class TestSparqlSourceHelpers:
     """SparqlSource static helper methods."""
 
     def test_extract_qid_from_uri(self):
-        assert SparqlSource.extract_qid("http://www.wikidata.org/entity/Q2774") == "Q2774"
+        assert (
+            SparqlSource.extract_qid("http://www.wikidata.org/entity/Q2774") == "Q2774"
+        )
 
     def test_extract_qid_from_bare_qid(self):
         assert SparqlSource.extract_qid("Q2774") == "Q2774"
 
     def test_binding_value_present(self):
-        binding = {"item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q2774"}}
-        assert SparqlSource.binding_value(binding, "item") == "http://www.wikidata.org/entity/Q2774"
+        binding = {
+            "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q2774"}
+        }
+        assert (
+            SparqlSource.binding_value(binding, "item")
+            == "http://www.wikidata.org/entity/Q2774"
+        )
 
     def test_binding_value_absent(self):
         binding = {"item": {"type": "uri", "value": "..."}}
@@ -108,7 +118,12 @@ class TestSparqlSourceBatchSplitting:
             json={
                 "results": {
                     "bindings": [
-                        {"item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q1"}},
+                        {
+                            "item": {
+                                "type": "uri",
+                                "value": "http://www.wikidata.org/entity/Q1",
+                            }
+                        },
                     ]
                 }
             }
@@ -117,7 +132,12 @@ class TestSparqlSourceBatchSplitting:
             json={
                 "results": {
                     "bindings": [
-                        {"item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q3"}},
+                        {
+                            "item": {
+                                "type": "uri",
+                                "value": "http://www.wikidata.org/entity/Q3",
+                            }
+                        },
                     ]
                 }
             }

--- a/tests/test_sparql_source.py
+++ b/tests/test_sparql_source.py
@@ -1,0 +1,148 @@
+import pytest
+
+from wxyc_catalog.sources.sparql import SparqlSource
+
+
+class TestSparqlSourceQueryExecution:
+    """SparqlSource should execute SPARQL queries and parse results."""
+
+    async def test_query_returns_bindings(self, httpx_mock):
+        """query() should return the bindings array from SPARQL JSON response."""
+        sparql_response = {
+            "results": {
+                "bindings": [
+                    {
+                        "item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q2774"},
+                        "itemLabel": {"type": "literal", "value": "Autechre"},
+                    },
+                ]
+            }
+        }
+        httpx_mock.add_response(json=sparql_response)
+
+        source = SparqlSource(
+            sparql_endpoint="https://query.wikidata.org/sparql",
+            rate_limit=1000,
+        )
+        bindings = await source.query("SELECT ?item ?itemLabel WHERE { ?item wdt:P1953 '14' }")
+        assert len(bindings) == 1
+        assert bindings[0]["item"]["value"] == "http://www.wikidata.org/entity/Q2774"
+        await source.close()
+
+    async def test_empty_results(self, httpx_mock):
+        """query() should return empty list when no results match."""
+        httpx_mock.add_response(json={"results": {"bindings": []}})
+
+        source = SparqlSource(rate_limit=1000)
+        bindings = await source.query("SELECT ?item WHERE { ?item wdt:P1953 '999999' }")
+        assert bindings == []
+        await source.close()
+
+    async def test_query_failure_returns_empty(self, httpx_mock):
+        """query() should return empty list on HTTP failure."""
+        httpx_mock.add_response(status_code=500)
+
+        source = SparqlSource(rate_limit=1000)
+        bindings = await source.query("SELECT ?item WHERE { ?item wdt:P31 wd:Q5 }")
+        assert bindings == []
+        await source.close()
+
+
+class TestSparqlSourceQidValidation:
+    """SparqlSource QID validation should accept Q-prefixed numbers only."""
+
+    def test_valid_qids(self):
+        source = SparqlSource(rate_limit=1000)
+        valid = source.validate_qids(["Q1", "Q2774", "Q12345678"])
+        assert valid == ["Q1", "Q2774", "Q12345678"]
+
+    def test_invalid_qids_filtered(self):
+        source = SparqlSource(rate_limit=1000)
+        valid = source.validate_qids(["Q2774", "P1953", "invalid", "", "Q1"])
+        assert valid == ["Q2774", "Q1"]
+
+    def test_empty_input(self):
+        source = SparqlSource(rate_limit=1000)
+        assert source.validate_qids([]) == []
+
+
+class TestSparqlSourceHelpers:
+    """SparqlSource static helper methods."""
+
+    def test_extract_qid_from_uri(self):
+        assert SparqlSource.extract_qid("http://www.wikidata.org/entity/Q2774") == "Q2774"
+
+    def test_extract_qid_from_bare_qid(self):
+        assert SparqlSource.extract_qid("Q2774") == "Q2774"
+
+    def test_binding_value_present(self):
+        binding = {"item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q2774"}}
+        assert SparqlSource.binding_value(binding, "item") == "http://www.wikidata.org/entity/Q2774"
+
+    def test_binding_value_absent(self):
+        binding = {"item": {"type": "uri", "value": "..."}}
+        assert SparqlSource.binding_value(binding, "missing") is None
+
+
+class TestSparqlSourceBatchSplitting:
+    """SparqlSource should split large QID lists into batched VALUES clauses."""
+
+    async def test_batch_splitting(self, httpx_mock):
+        """Large QID lists should be split into batches."""
+        sparql_response = {"results": {"bindings": []}}
+        httpx_mock.add_response(json=sparql_response)
+        httpx_mock.add_response(json=sparql_response)
+
+        source = SparqlSource(batch_size=2, rate_limit=1000)
+        await source.query_batched(
+            "SELECT ?item WHERE {{ VALUES ?item {{ {values} }} ?item wdt:P31 wd:Q5 }}",
+            ["Q1", "Q2", "Q3"],
+        )
+        # Should have made 2 requests (batch of 2 + batch of 1)
+        assert len(httpx_mock.get_requests()) == 2
+        await source.close()
+
+    async def test_batch_results_combined(self, httpx_mock):
+        """Results from all batches should be combined."""
+        httpx_mock.add_response(
+            json={
+                "results": {
+                    "bindings": [
+                        {"item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q1"}},
+                    ]
+                }
+            }
+        )
+        httpx_mock.add_response(
+            json={
+                "results": {
+                    "bindings": [
+                        {"item": {"type": "uri", "value": "http://www.wikidata.org/entity/Q3"}},
+                    ]
+                }
+            }
+        )
+
+        source = SparqlSource(batch_size=2, rate_limit=1000)
+        results = await source.query_batched(
+            "SELECT ?item WHERE {{ VALUES ?item {{ {values} }} ?item wdt:P31 wd:Q5 }}",
+            ["Q1", "Q2", "Q3"],
+        )
+        assert len(results) == 2
+        await source.close()
+
+    async def test_batch_validates_qids(self, httpx_mock):
+        """query_batched should filter invalid QIDs before batching."""
+        sparql_response = {"results": {"bindings": []}}
+        httpx_mock.add_response(json=sparql_response)
+
+        source = SparqlSource(batch_size=50, rate_limit=1000)
+        await source.query_batched(
+            "SELECT ?item WHERE {{ VALUES ?item {{ {values} }} }}",
+            ["Q1", "invalid", "Q2"],
+        )
+        # Only valid QIDs should be in the request
+        request = httpx_mock.get_requests()[0]
+        query_param = str(request.url)
+        assert "invalid" not in query_param
+        await source.close()


### PR DESCRIPTION
## Summary

- Implement four shared async transport classes in `wxyc_catalog.sources` that standardize connection management, rate limiting, and retry logic across WXYC ETL repos
- **PgSource**: async PostgreSQL pool via asyncpg with lazy connect, graceful `None` returns on failure, automatic reconnect, and batch query helpers
- **HttpSource**: shared `httpx.AsyncClient` session with token-bucket rate limiting, exponential backoff retry on 429/403, configurable timeout
- **SparqlSource**: extends HttpSource with SPARQL query execution, result binding parsing, QID validation (`Q\d+`), and batch splitting into VALUES clauses
- **ArchiveSource**: directory and tar-indexed file loading with SQLite index persistence, batch reads grouped by storage unit, async via `asyncio.to_thread()`
- 42 contract tests covering all transport behaviors

Closes WXYC/wxyc-catalog#2

## Test plan

- [x] All 42 tests pass (`pytest tests/ -v`)
- [x] `ruff check` and `ruff format --check` report no issues
- [x] All four transport classes importable from `wxyc_catalog.sources` and `wxyc_catalog`
- [x] PgSource: lazy connect, graceful None, reconnect, fetchall/fetchone/execute/fetch_with_unnest
- [x] HttpSource: rate limiting delays requests, retries on 429/403, returns None after max retries, no retry on 404/500
- [x] SparqlSource: query returns bindings, validates QIDs, batch splits large QID lists, extracts QIDs from URIs
- [x] ArchiveSource: loads from directories and tar archives, creates/reuses SQLite index, batch loading, handles missing files