### PR TITLE
Support MySQL 4.1 auth via mysql-connector-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-mysql = ["pymysql>=1.0"]
+mysql = ["mysql-connector-python>=8.0"]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-httpx>=0.30.0",
     "ruff>=0.4.0",
-    "pymysql>=1.0",
+    "mysql-connector-python>=8.0",
 ]
 
 [project.scripts]

--- a/src/wxyc_catalog/db.py
+++ b/src/wxyc_catalog/db.py
@@ -1,27 +1,60 @@
-"""MySQL connection utilities for WXYC catalog databases."""
+"""MySQL connection utilities for WXYC catalog databases.
+
+Supports MySQL 4.1+ (Kattare runs MySQL 4.1.22) via mysql-connector-python,
+with pymysql as a fallback for newer servers.
+"""
 
 from __future__ import annotations
 
-from urllib.parse import urlparse
+import logging
+from urllib.parse import unquote, urlparse
 
-import pymysql
+logger = logging.getLogger(__name__)
 
 
 def connect_mysql(db_url: str):
     """Connect to MySQL using a URL string.
 
+    Uses mysql-connector-python when available (supports MySQL 4.1's old password
+    auth), falling back to pymysql for newer servers.
+
     Args:
         db_url: MySQL connection URL (mysql://user:pass@host:port/dbname).
 
     Returns:
-        A pymysql connection object.
+        A DB-API 2.0 connection object.
     """
     parsed = urlparse(db_url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 3306
+    user = unquote(parsed.username or "root")
+    password = unquote(parsed.password or "")
+    database = parsed.path.lstrip("/")
+
+    try:
+        import mysql.connector
+
+        logger.info("Connecting to MySQL via mysql-connector-python (%s:%d)", host, port)
+        return mysql.connector.connect(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
+            charset="utf8",
+            allow_old_password=True,
+        )
+    except ImportError:
+        pass
+
+    import pymysql
+
+    logger.info("Connecting to MySQL via pymysql (%s:%d)", host, port)
     return pymysql.connect(
-        host=parsed.hostname or "localhost",
-        port=parsed.port or 3306,
-        user=parsed.username or "root",
-        password=parsed.password or "",
-        database=parsed.path.lstrip("/"),
+        host=host,
+        port=port,
+        user=user,
+        password=password,
+        database=database,
         charset="utf8",
     )


### PR DESCRIPTION
## Summary
- Switch primary MySQL driver from pymysql to mysql-connector-python, which supports `allow_old_password=True` for MySQL 4.1's pre-plugin authentication
- Fall back to pymysql when mysql-connector-python is not installed
- URL-decode credentials from connection URLs to handle special characters

Kattare runs MySQL 4.1.22, which doesn't support plugin-based auth. pymysql 1.x dropped old password support, causing `received unknown auth switch request` errors in the library sync workflow.

## Test plan
- [ ] `wxyc-export-to-sqlite --catalog-source tubafrenzy --catalog-db-url <url>` connects to Kattare MySQL 4.1 successfully
- [ ] Existing unit tests pass