### PR TITLE
Add label column to library.db export

### DIFF
--- a/src/wxyc_catalog/catalog_source.py
+++ b/src/wxyc_catalog/catalog_source.py
@@ -25,7 +25,7 @@ class CatalogSource(Protocol):
 
     def fetch_library_rows(self) -> list[dict[str, Any]]:
         """Return library rows. Keys: id, title, artist, call_letters,
-        artist_call_number, release_call_number, genre, format, alternate_artist_name."""
+        artist_call_number, release_call_number, genre, format, alternate_artist_name, label."""
         ...
 
     def fetch_alternate_names(self) -> set[str]:
@@ -90,17 +90,31 @@ class TubafrenzySource:
             "genre",
             "format",
             "alternate_artist_name",
+            "label",
         ]
         cur = self._conn.cursor()
         cur.execute("""
             SELECT
                 r.ID, r.TITLE, lc.PRESENTATION_NAME, lc.CALL_LETTERS,
                 lc.CALL_NUMBERS, r.CALL_NUMBERS, g.REFERENCE_NAME,
-                f.REFERENCE_NAME, r.ALTERNATE_ARTIST_NAME
+                f.REFERENCE_NAME, r.ALTERNATE_ARTIST_NAME,
+                label_sub.label_name
             FROM LIBRARY_RELEASE r
             JOIN LIBRARY_CODE lc ON r.LIBRARY_CODE_ID = lc.ID
             JOIN FORMAT f ON r.FORMAT_ID = f.ID
             JOIN GENRE g ON lc.GENRE_ID = g.ID
+            LEFT JOIN (
+                SELECT rr.LIBRARY_RELEASE_ID, c.NAME as label_name,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY rr.LIBRARY_RELEASE_ID
+                           ORDER BY rr.ROTATION_ADD_DATE DESC
+                       ) as rn
+                FROM ROTATION_RELEASE rr
+                JOIN COMPANY c ON rr.COMPANY_ID = c.ID
+                WHERE rr.LIBRARY_RELEASE_ID IS NOT NULL
+                  AND rr.LIBRARY_RELEASE_ID > 0
+            ) label_sub ON label_sub.LIBRARY_RELEASE_ID = r.ID
+                       AND label_sub.rn = 1
         """)
         rows = list(cur)
         cur.close()
@@ -183,7 +197,8 @@ class BackendServiceSource:
                     gac.artist_genre_code AS artist_call_number,
                     l.code_number AS release_call_number,
                     g.genre_name AS genre, f.format_name AS format,
-                    l.alternate_artist_name
+                    l.alternate_artist_name,
+                    NULL AS label
                 FROM wxyc_schema.library l
                 JOIN wxyc_schema.artists a ON l.artist_id = a.id
                 JOIN wxyc_schema.format f ON l.format_id = f.id

--- a/src/wxyc_catalog/export_to_sqlite.py
+++ b/src/wxyc_catalog/export_to_sqlite.py
@@ -37,7 +37,7 @@ def export_rows_to_sqlite(rows: list[dict], output_path: Path) -> None:
     Args:
         rows: List of dicts with keys: id, title, artist, call_letters,
               artist_call_number, release_call_number, genre, format,
-              alternate_artist_name.
+              alternate_artist_name, label.
         output_path: Path where the SQLite database will be written.
                      An existing file at this path will be removed first.
     """
@@ -57,7 +57,8 @@ def export_rows_to_sqlite(rows: list[dict], output_path: Path) -> None:
             release_call_number INTEGER,
             genre TEXT,
             format TEXT,
-            alternate_artist_name TEXT
+            alternate_artist_name TEXT,
+            label TEXT
         )
     """)
 
@@ -75,8 +76,9 @@ def export_rows_to_sqlite(rows: list[dict], output_path: Path) -> None:
         cur.execute(
             """
             INSERT INTO library (id, title, artist, call_letters, artist_call_number,
-                                 release_call_number, genre, format, alternate_artist_name)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                                 release_call_number, genre, format, alternate_artist_name,
+                                 label)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 row["id"],
@@ -88,6 +90,7 @@ def export_rows_to_sqlite(rows: list[dict], output_path: Path) -> None:
                 row["genre"],
                 row["format"],
                 row.get("alternate_artist_name"),
+                row.get("label"),
             ),
         )
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -25,6 +25,7 @@ def make_library_row(**overrides: Any) -> dict[str, Any]:
         "genre": "Rock",
         "format": "CD",
         "alternate_artist_name": None,
+        "label": None,
     }
     defaults.update(overrides)
     return defaults
@@ -41,6 +42,7 @@ EXAMPLE_LIBRARY_ROWS: list[dict[str, Any]] = [
         release_call_number=1,
         genre="Rock",
         format="CD",
+        label="Sonamos",
     ),
     make_library_row(
         id=9002,
@@ -51,6 +53,7 @@ EXAMPLE_LIBRARY_ROWS: list[dict[str, Any]] = [
         release_call_number=5,
         genre="Rock",
         format="CD",
+        label="Duophonic",
     ),
     make_library_row(
         id=9003,
@@ -61,6 +64,7 @@ EXAMPLE_LIBRARY_ROWS: list[dict[str, Any]] = [
         release_call_number=2,
         genre="Rock",
         format="CD",
+        label="Matador Records",
     ),
     make_library_row(
         id=9004,
@@ -71,6 +75,7 @@ EXAMPLE_LIBRARY_ROWS: list[dict[str, Any]] = [
         release_call_number=1,
         genre="Rock",
         format="Vinyl LP",
+        label="Drag City",
     ),
     make_library_row(
         id=9005,
@@ -81,6 +86,7 @@ EXAMPLE_LIBRARY_ROWS: list[dict[str, Any]] = [
         release_call_number=1,
         genre="Electronic",
         format="Vinyl LP",
+        label="self-released",
     ),
 ]
 

--- a/tests/unit/test_catalog_source.py
+++ b/tests/unit/test_catalog_source.py
@@ -117,7 +117,9 @@ class TestTubafrenzySourceFetchLibraryRows:
 
     @patch("wxyc_catalog.catalog_source.connect_mysql")
     def test_returns_list_of_dicts(self, mock_connect) -> None:
-        cursor = _make_mock_cursor([(1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None)])
+        cursor = _make_mock_cursor(
+            [(1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, "Sonamos")]
+        )
         mock_connect.return_value.cursor.return_value = cursor
 
         source = TubafrenzySource("mysql://user:pass@host/db")
@@ -133,6 +135,21 @@ class TestTubafrenzySourceFetchLibraryRows:
         assert rows[0]["genre"] == "Rock"
         assert rows[0]["format"] == "LP"
         assert rows[0]["alternate_artist_name"] is None
+        assert rows[0]["label"] == "Sonamos"
+
+    @patch("wxyc_catalog.catalog_source.connect_mysql")
+    def test_returns_null_label(self, mock_connect) -> None:
+        """Rows without a matching rotation release should have label=None."""
+        cursor = _make_mock_cursor(
+            [(1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, None)]
+        )
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        rows = source.fetch_library_rows()
+
+        assert len(rows) == 1
+        assert rows[0]["label"] is None
 
 
 class TestTubafrenzySourceFetchAlternateNames:
@@ -269,9 +286,10 @@ class TestBackendServiceSourceFetchLibraryRows:
             ("genre",),
             ("format",),
             ("alternate_artist_name",),
+            ("label",),
         ]
         cursor.fetchall.return_value = [
-            (1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None)
+            (1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, None)
         ]
 
         source = BackendServiceSource("postgresql://user:pass@host/db")
@@ -281,6 +299,7 @@ class TestBackendServiceSourceFetchLibraryRows:
         assert rows[0]["id"] == 1
         assert rows[0]["title"] == "DOGA"
         assert rows[0]["artist"] == "Juana Molina"
+        assert rows[0]["label"] is None
 
     @patch("wxyc_catalog.catalog_source.psycopg")
     def test_sql_references_wxyc_schema(self, mock_psycopg) -> None:

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -149,6 +149,33 @@ class TestExportRowsToSqlite:
         conn.close()
         assert count == 1
 
+    def test_exports_label(self, tmp_path: Path) -> None:
+        """Rows with label should store it in SQLite."""
+        db_path = tmp_path / "library.db"
+        export_rows_to_sqlite(
+            [make_library_row(id=1, artist="Juana Molina", title="DOGA", label="Sonamos")],
+            db_path,
+        )
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute("SELECT label FROM library WHERE id = 1").fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] == "Sonamos"
+
+    def test_exports_null_label(self, tmp_path: Path) -> None:
+        """Rows with None label should store NULL in SQLite."""
+        db_path = tmp_path / "library.db"
+        export_rows_to_sqlite([make_library_row(id=1, label=None)], db_path)
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute("SELECT label FROM library WHERE id = 1").fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row[0] is None
+
     def test_mixed_rows_with_and_without_alternate(self, tmp_path: Path) -> None:
         """Mix of rows with and without alternate_artist_name should export correctly."""
         db_path = tmp_path / "library.db"


### PR DESCRIPTION
## Summary

- TubafrenzySource: JOIN ROTATION_RELEASE -> COMPANY with a LEFT JOIN subquery picking the most recent rotation release's company name per library release
- BackendServiceSource: returns NULL for label (Backend-Service doesn't have label data yet)
- Add `label TEXT` column to the SQLite library table schema
- Update test factories with label data matching canonical WXYC example triples

Closes #10

## Test plan

- [x] New unit tests: `test_exports_label`, `test_exports_null_label`, `test_returns_null_label`
- [x] All 48 catalog_source + export tests pass
- [x] Full unit suite passes (82 passed, 3 pre-existing failures from missing pymysql)
- [x] Lint clean (`ruff check`)
- [ ] Run export against staging tubafrenzy and verify label column populated