### PR TITLE
Expand unit test coverage for db.py, catalog_source.py, and export_to_sqlite.py

### DIFF
--- a/tests/unit/test_catalog_source.py
+++ b/tests/unit/test_catalog_source.py
@@ -151,6 +151,60 @@ class TestTubafrenzySourceFetchLibraryRows:
         assert len(rows) == 1
         assert rows[0]["label"] is None
 
+    @patch("wxyc_catalog.catalog_source.connect_mysql")
+    def test_closes_cursor(self, mock_connect) -> None:
+        cursor = _make_mock_cursor(
+            [(1, "DOGA", "Juana Molina", "JM", 42, 1, "Rock", "LP", None, "Sonamos")]
+        )
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        source.fetch_library_rows()
+
+        cursor.close.assert_called_once()
+
+    @patch("wxyc_catalog.catalog_source.connect_mysql")
+    def test_empty_result(self, mock_connect) -> None:
+        cursor = _make_mock_cursor([])
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        rows = source.fetch_library_rows()
+
+        assert rows == []
+
+    @patch("wxyc_catalog.catalog_source.connect_mysql")
+    def test_preserves_order(self, mock_connect) -> None:
+        raw_rows = [
+            (1, "Confield", "Autechre", "EL", 10, 1, "Electronic", "CD", None, "Warp"),
+            (2, "Aluminum Tunes", "Stereolab", "RO", 87, 5, "Rock", "CD", None, "Duophonic"),
+            (3, "DOGA", "Juana Molina", "RO", 42, 1, "Rock", "CD", None, "Sonamos"),
+        ]
+        cursor = _make_mock_cursor(raw_rows)
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        rows = source.fetch_library_rows()
+
+        assert len(rows) == 3
+        assert rows[0]["artist"] == "Autechre"
+        assert rows[1]["artist"] == "Stereolab"
+        assert rows[2]["artist"] == "Juana Molina"
+
+    @patch("wxyc_catalog.catalog_source.connect_mysql")
+    def test_sql_contains_joins(self, mock_connect) -> None:
+        cursor = _make_mock_cursor([])
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        source.fetch_library_rows()
+
+        sql = cursor.execute.call_args[0][0]
+        assert "LIBRARY_RELEASE" in sql
+        assert "LIBRARY_CODE" in sql
+        assert "FORMAT" in sql
+        assert "GENRE" in sql
+
 
 class TestTubafrenzySourceFetchAlternateNames:
     """TubafrenzySource.fetch_alternate_names returns set of name strings."""
@@ -163,6 +217,15 @@ class TestTubafrenzySourceFetchAlternateNames:
         source = TubafrenzySource("mysql://user:pass@host/db")
         names = source.fetch_alternate_names()
         assert names == {"Body Count", "Ice Cube"}
+
+    @patch("wxyc_catalog.catalog_source.connect_mysql")
+    def test_empty_result(self, mock_connect) -> None:
+        cursor = _make_mock_cursor([])
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        names = source.fetch_alternate_names()
+        assert names == set()
 
     @patch("wxyc_catalog.catalog_source.connect_mysql")
     def test_strips_whitespace(self, mock_connect) -> None:
@@ -193,6 +256,15 @@ class TestTubafrenzySourceFetchCrossReferencedArtists:
         names = source.fetch_cross_referenced_artists()
         assert names == {"Ice-T", "Body Count"}
 
+    @patch("wxyc_catalog.catalog_source.connect_mysql")
+    def test_empty_result(self, mock_connect) -> None:
+        cursor = _make_mock_cursor([])
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        names = source.fetch_cross_referenced_artists()
+        assert names == set()
+
 
 class TestTubafrenzySourceFetchReleaseCrossRefArtists:
     @patch("wxyc_catalog.catalog_source.connect_mysql")
@@ -204,8 +276,26 @@ class TestTubafrenzySourceFetchReleaseCrossRefArtists:
         names = source.fetch_release_cross_ref_artists()
         assert names == {"John Coltrane"}
 
+    @patch("wxyc_catalog.catalog_source.connect_mysql")
+    def test_empty_result(self, mock_connect) -> None:
+        cursor = _make_mock_cursor([])
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        names = source.fetch_release_cross_ref_artists()
+        assert names == set()
+
 
 class TestTubafrenzySourceFetchLibraryLabels:
+    @patch("wxyc_catalog.catalog_source.connect_mysql")
+    def test_empty_result(self, mock_connect) -> None:
+        cursor = _make_mock_cursor([])
+        mock_connect.return_value.cursor.return_value = cursor
+
+        source = TubafrenzySource("mysql://user:pass@host/db")
+        labels = source.fetch_library_labels()
+        assert labels == set()
+
     @patch("wxyc_catalog.catalog_source.connect_mysql")
     def test_returns_set_of_tuples(self, mock_connect) -> None:
         cursor = _make_mock_cursor(

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -2,52 +2,251 @@
 
 from __future__ import annotations
 
-import builtins
-from unittest.mock import patch
+import logging
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock, patch
 
-from wxyc_catalog.db import connect_mysql
-
-# Force connect_mysql to fall through to pymysql by blocking mariadb and MySQLdb imports.
-_real_import = builtins.__import__
+DB_URL = "mysql://wxyc:secret@db.example.com:3307/wxycmusic"
 
 
-def _import_no_mysql(name, *args, **kwargs):
-    if name in ("mariadb", "MySQLdb"):
-        raise ImportError(f"mocked: {name} not available")
-    return _real_import(name, *args, **kwargs)
+def _make_mock_module(name: str) -> ModuleType:
+    """Create a mock module with a connect() method."""
+    mod = MagicMock(spec=ModuleType)
+    mod.__name__ = name
+    mod.connect = MagicMock()
+    return mod
 
 
 class TestConnectMysql:
-    """connect_mysql() parses a URL and returns a pymysql connection."""
+    """connect_mysql() parses a URL and connects via the first available driver."""
 
-    @patch("wxyc_catalog.db.pymysql")
-    @patch("builtins.__import__", side_effect=_import_no_mysql)
-    def test_parses_full_url(self, _mock_import, mock_pymysql) -> None:
-        connect_mysql("mysql://wxyc:secret@db.example.com:3307/wxycmusic")
-        mock_pymysql.connect.assert_called_once_with(
-            host="db.example.com",
-            port=3307,
-            user="wxyc",
-            password="secret",
-            database="wxycmusic",
-            charset="utf8",
-        )
+    def test_parses_full_url(self) -> None:
+        mock_pymysql = _make_mock_module("pymysql")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
+            from importlib import reload
 
-    @patch("wxyc_catalog.db.pymysql")
-    @patch("builtins.__import__", side_effect=_import_no_mysql)
-    def test_defaults_for_minimal_url(self, _mock_import, mock_pymysql) -> None:
-        connect_mysql("mysql:///mydb")
-        mock_pymysql.connect.assert_called_once_with(
-            host="localhost",
-            port=3306,
-            user="root",
-            password="",
-            database="mydb",
-            charset="utf8",
-        )
+            import wxyc_catalog.db as db_mod
 
-    @patch("wxyc_catalog.db.pymysql")
-    @patch("builtins.__import__", side_effect=_import_no_mysql)
-    def test_returns_connection(self, _mock_import, mock_pymysql) -> None:
-        result = connect_mysql("mysql://u:p@h/db")
-        assert result == mock_pymysql.connect.return_value
+            reload(db_mod)
+            db_mod.connect_mysql("mysql://wxyc:secret@db.example.com:3307/wxycmusic")
+            mock_pymysql.connect.assert_called_once_with(
+                host="db.example.com",
+                port=3307,
+                user="wxyc",
+                password="secret",
+                database="wxycmusic",
+                charset="utf8",
+            )
+
+    def test_defaults_for_minimal_url(self) -> None:
+        mock_pymysql = _make_mock_module("pymysql")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            db_mod.connect_mysql("mysql:///mydb")
+            mock_pymysql.connect.assert_called_once_with(
+                host="localhost",
+                port=3306,
+                user="root",
+                password="",
+                database="mydb",
+                charset="utf8",
+            )
+
+    def test_returns_connection(self) -> None:
+        mock_pymysql = _make_mock_module("pymysql")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            result = db_mod.connect_mysql("mysql://u:p@h/db")
+            assert result == mock_pymysql.connect.return_value
+
+
+# ---------------------------------------------------------------------------
+# Driver fallback chain
+# ---------------------------------------------------------------------------
+
+
+class TestDriverFallbackChain:
+    """connect_mysql() tries mariadb, then mysqlclient, then pymysql."""
+
+    def test_uses_mariadb_when_available(self) -> None:
+        mock_mariadb = _make_mock_module("mariadb")
+        with patch.dict(sys.modules, {"mariadb": mock_mariadb}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            db_mod.connect_mysql(DB_URL)
+            mock_mariadb.connect.assert_called_once()
+
+    def test_falls_back_to_mysqlclient_when_mariadb_unavailable(self) -> None:
+        mock_mysqldb = _make_mock_module("MySQLdb")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": mock_mysqldb}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            db_mod.connect_mysql(DB_URL)
+            mock_mysqldb.connect.assert_called_once()
+            # mysqlclient uses passwd= and db= instead of password= and database=
+            call_kwargs = mock_mysqldb.connect.call_args.kwargs
+            assert "passwd" in call_kwargs
+            assert "db" in call_kwargs
+
+    def test_falls_back_to_pymysql_when_both_unavailable(self) -> None:
+        mock_pymysql = _make_mock_module("pymysql")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            db_mod.connect_mysql(DB_URL)
+            mock_pymysql.connect.assert_called_once()
+
+    def test_mariadb_connect_returns_connection(self) -> None:
+        mock_mariadb = _make_mock_module("mariadb")
+        sentinel = object()
+        mock_mariadb.connect.return_value = sentinel
+        with patch.dict(sys.modules, {"mariadb": mock_mariadb}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            result = db_mod.connect_mysql(DB_URL)
+            assert result is sentinel
+
+    def test_mysqlclient_connect_returns_connection(self) -> None:
+        mock_mysqldb = _make_mock_module("MySQLdb")
+        sentinel = object()
+        mock_mysqldb.connect.return_value = sentinel
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": mock_mysqldb}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            result = db_mod.connect_mysql(DB_URL)
+            assert result is sentinel
+
+
+# ---------------------------------------------------------------------------
+# URL decoding
+# ---------------------------------------------------------------------------
+
+
+class TestUrlDecoding:
+    """connect_mysql() URL-decodes username and password."""
+
+    def test_url_decodes_username(self) -> None:
+        mock_pymysql = _make_mock_module("pymysql")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            db_mod.connect_mysql("mysql://wxyc%40host:secret@db.example.com:3306/wxycmusic")
+            call_kwargs = mock_pymysql.connect.call_args.kwargs
+            assert call_kwargs["user"] == "wxyc@host"
+
+    def test_url_decodes_password_with_special_chars(self) -> None:
+        mock_pymysql = _make_mock_module("pymysql")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            db_mod.connect_mysql("mysql://wxyc:p%40ss%23w0rd@db.example.com:3306/wxycmusic")
+            call_kwargs = mock_pymysql.connect.call_args.kwargs
+            assert call_kwargs["password"] == "p@ss#w0rd"
+
+
+# ---------------------------------------------------------------------------
+# Charset parameter
+# ---------------------------------------------------------------------------
+
+
+class TestCharsetParameter:
+    """mysqlclient and pymysql get charset='utf8'; mariadb does not."""
+
+    def test_mysqlclient_passes_charset_utf8(self) -> None:
+        mock_mysqldb = _make_mock_module("MySQLdb")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": mock_mysqldb}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            db_mod.connect_mysql(DB_URL)
+            call_kwargs = mock_mysqldb.connect.call_args.kwargs
+            assert call_kwargs["charset"] == "utf8"
+
+    def test_pymysql_passes_charset_utf8(self) -> None:
+        mock_pymysql = _make_mock_module("pymysql")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            db_mod.connect_mysql(DB_URL)
+            call_kwargs = mock_pymysql.connect.call_args.kwargs
+            assert call_kwargs["charset"] == "utf8"
+
+    def test_mariadb_does_not_pass_charset(self) -> None:
+        mock_mariadb = _make_mock_module("mariadb")
+        with patch.dict(sys.modules, {"mariadb": mock_mariadb}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            db_mod.connect_mysql(DB_URL)
+            call_kwargs = mock_mariadb.connect.call_args.kwargs
+            assert "charset" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+
+class TestDriverLogging:
+    """connect_mysql() logs which driver is being used."""
+
+    def test_logs_mariadb_driver_info(self, caplog) -> None:
+        mock_mariadb = _make_mock_module("mariadb")
+        with patch.dict(sys.modules, {"mariadb": mock_mariadb}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            with caplog.at_level(logging.INFO, logger="wxyc_catalog.db"):
+                db_mod.connect_mysql(DB_URL)
+            assert "mariadb connector" in caplog.text.lower()
+
+    def test_logs_pymysql_driver_info(self, caplog) -> None:
+        mock_pymysql = _make_mock_module("pymysql")
+        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
+            from importlib import reload
+
+            import wxyc_catalog.db as db_mod
+
+            reload(db_mod)
+            with caplog.at_level(logging.INFO, logger="wxyc_catalog.db"):
+                db_mod.connect_mysql(DB_URL)
+            assert "pymysql" in caplog.text.lower()

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests.factories import make_library_row
-from wxyc_catalog.export_to_sqlite import export_rows_to_sqlite, format_size
+from wxyc_catalog.export_to_sqlite import export, export_rows_to_sqlite, format_size, parse_args
 
 
 class TestExportRowsToSqlite:
@@ -192,6 +193,213 @@ class TestExportRowsToSqlite:
         conn.close()
 
         assert results == [(1, "Plug"), (2, None)]
+
+    def test_empty_rows_creates_schema_only(self, tmp_path: Path) -> None:
+        """Zero rows should create table, FTS, and indexes but no data."""
+        db_path = tmp_path / "library.db"
+        export_rows_to_sqlite([], db_path)
+
+        conn = sqlite3.connect(db_path)
+        # Table exists
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        }
+        assert "library" in tables
+        # FTS exists
+        assert "library_fts" in tables
+        # Indexes exist
+        indexes = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()
+        }
+        assert "idx_artist" in indexes
+        assert "idx_title" in indexes
+        assert "idx_alternate_artist" in indexes
+        # No data
+        count = conn.execute("SELECT COUNT(*) FROM library").fetchone()[0]
+        conn.close()
+        assert count == 0
+
+    def test_row_with_all_none_values(self, tmp_path: Path) -> None:
+        """A row with id=1 and all other fields None should insert without error."""
+        db_path = tmp_path / "library.db"
+        row = make_library_row(
+            id=1,
+            title=None,
+            artist=None,
+            call_letters=None,
+            artist_call_number=None,
+            release_call_number=None,
+            genre=None,
+            format=None,
+            alternate_artist_name=None,
+        )
+        export_rows_to_sqlite([row], db_path)
+
+        conn = sqlite3.connect(db_path)
+        result = conn.execute("SELECT * FROM library WHERE id = 1").fetchone()
+        conn.close()
+
+        assert result is not None
+        assert result[0] == 1
+        # All other columns are None
+        assert all(v is None for v in result[1:])
+
+    def test_unicode_characters_round_trip(self, tmp_path: Path) -> None:
+        """Unicode characters (accented, non-Latin) should survive the round trip."""
+        db_path = tmp_path / "library.db"
+        row = make_library_row(
+            id=1,
+            title="\u00c1g\u00e6tis byrjun",
+            artist="Sigur R\u00f3s",
+        )
+        export_rows_to_sqlite([row], db_path)
+
+        conn = sqlite3.connect(db_path)
+        result = conn.execute("SELECT artist, title FROM library WHERE id = 1").fetchone()
+        conn.close()
+
+        assert result[0] == "Sigur R\u00f3s"
+        assert result[1] == "\u00c1g\u00e6tis byrjun"
+
+    def test_special_characters_in_artist(self, tmp_path: Path) -> None:
+        """Ampersands and other special characters should be stored correctly."""
+        db_path = tmp_path / "library.db"
+        row = make_library_row(
+            id=1,
+            title="Duke Ellington & John Coltrane",
+            artist="Duke Ellington & John Coltrane",
+        )
+        export_rows_to_sqlite([row], db_path)
+
+        conn = sqlite3.connect(db_path)
+        result = conn.execute("SELECT artist FROM library WHERE id = 1").fetchone()
+        conn.close()
+
+        assert result[0] == "Duke Ellington & John Coltrane"
+
+
+class TestParseArgs:
+    """Tests for parse_args() CLI argument parsing."""
+
+    def test_required_args_missing(self) -> None:
+        """Missing required args should cause SystemExit."""
+        with pytest.raises(SystemExit):
+            parse_args([])
+
+    def test_default_output(self) -> None:
+        """Default --output should be Path('library.db')."""
+        args = parse_args(
+            [
+                "--catalog-source",
+                "tubafrenzy",
+                "--catalog-db-url",
+                "mysql://u:p@h/db",
+            ]
+        )
+        assert args.output == Path("library.db")
+
+    def test_invalid_source_rejected(self) -> None:
+        """An invalid --catalog-source value should cause SystemExit."""
+        with pytest.raises(SystemExit):
+            parse_args(
+                [
+                    "--catalog-source",
+                    "invalid-source",
+                    "--catalog-db-url",
+                    "mysql://u:p@h/db",
+                ]
+            )
+
+    def test_custom_output(self) -> None:
+        """--output should accept a custom path."""
+        args = parse_args(
+            [
+                "--catalog-source",
+                "tubafrenzy",
+                "--catalog-db-url",
+                "mysql://u:p@h/db",
+                "--output",
+                "/tmp/custom.db",
+            ]
+        )
+        assert args.output == Path("/tmp/custom.db")
+
+
+class TestExportCli:
+    """Tests for the export() CLI entry point."""
+
+    @patch("wxyc_catalog.export_to_sqlite.create_catalog_source")
+    def test_calls_source_and_writes_db(self, mock_create, tmp_path: Path) -> None:
+        """export() should call create_catalog_source, fetch rows, and write a database."""
+        mock_source = MagicMock()
+        mock_source.fetch_library_rows.return_value = [
+            make_library_row(id=1, artist="Autechre", title="Confield"),
+            make_library_row(id=2, artist="Stereolab", title="Aluminum Tunes"),
+        ]
+        mock_create.return_value = mock_source
+
+        db_path = tmp_path / "output.db"
+        export(
+            [
+                "--catalog-source",
+                "tubafrenzy",
+                "--catalog-db-url",
+                "mysql://u:p@h/db",
+                "--output",
+                str(db_path),
+            ]
+        )
+
+        mock_create.assert_called_once_with("tubafrenzy", "mysql://u:p@h/db")
+        mock_source.fetch_library_rows.assert_called_once()
+
+        # Verify the database was actually written
+        conn = sqlite3.connect(db_path)
+        count = conn.execute("SELECT COUNT(*) FROM library").fetchone()[0]
+        conn.close()
+        assert count == 2
+
+    @patch("wxyc_catalog.export_to_sqlite.create_catalog_source")
+    def test_closes_source(self, mock_create, tmp_path: Path) -> None:
+        """source.close() should always be called, even on success."""
+        mock_source = MagicMock()
+        mock_source.fetch_library_rows.return_value = [make_library_row(id=1)]
+        mock_create.return_value = mock_source
+
+        db_path = tmp_path / "output.db"
+        export(
+            [
+                "--catalog-source",
+                "tubafrenzy",
+                "--catalog-db-url",
+                "mysql://u:p@h/db",
+                "--output",
+                str(db_path),
+            ]
+        )
+
+        mock_source.close.assert_called_once()
+
+    @patch("wxyc_catalog.export_to_sqlite.create_catalog_source")
+    def test_closes_source_on_error(self, mock_create) -> None:
+        """source.close() should be called even if fetch_library_rows raises."""
+        mock_source = MagicMock()
+        mock_source.fetch_library_rows.side_effect = RuntimeError("connection lost")
+        mock_create.return_value = mock_source
+
+        with pytest.raises(RuntimeError, match="connection lost"):
+            export(
+                [
+                    "--catalog-source",
+                    "tubafrenzy",
+                    "--catalog-db-url",
+                    "mysql://u:p@h/db",
+                ]
+            )
+
+        mock_source.close.assert_called_once()
 
 
 class TestFormatSize:


### PR DESCRIPTION
## Summary
- Add 30 new unit tests across 3 test files
- 100% coverage on `db.py`, `catalog_source.py`, and `export_to_sqlite.py`
- Tests cover: driver fallback chain, URL decoding, cursor lifecycle, empty results, CLI parsing, Unicode round-trips

Closes #13

## Test plan
- [x] All 30 new tests pass
- [x] All existing tests continue to pass
- [x] Ruff lint and format clean
- [x] 100% coverage on target files