### PR TITLE
Simplify connect_mysql to pymysql-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ class CatalogSource(Protocol):
 
 | Source | Database | Connection |
 |--------|----------|------------|
-| `TubafrenzySource` | MySQL 4.1+ (Kattare) | `mysqlclient` (C-based libmysqlclient), pymysql fallback |
+| `TubafrenzySource` | MySQL 4.1+ (Kattare) | `pymysql` |
 | `BackendServiceSource` | PostgreSQL (Backend-Service) | `psycopg` |
 
 Use the factory function to create a source by name:
@@ -48,7 +48,7 @@ source = create_catalog_source("backend-service", "postgresql://user:pass@host/d
 
 ### MySQL 4.1 Compatibility
 
-Kattare runs MySQL 4.1.22 with old-format (16-byte) password hashes. Modern pure-Python MySQL drivers (pymysql, mysql-connector-python) refuse to authenticate with old passwords on security grounds. The `connect_mysql()` helper uses `mysqlclient` (C-based, backed by libmysqlclient) as the primary driver, which handles old password auth natively. Falls back to `pymysql` when `mysqlclient` is not installed. Credentials in the connection URL are URL-decoded to handle special characters.
+Kattare runs MySQL 4.1.22 with old-format password hashes. No modern Python MySQL driver supports this auth protocol. The daily library sync workflow (`discogs-etl/scripts/sync-library.sh`) uses the MariaDB `mysql` CLI client instead, which handles old auth natively. The `connect_mysql()` function in this package uses pymysql, which works with MySQL 5.x+ servers.
 
 ## Installation
 
@@ -121,7 +121,7 @@ export_rows_to_sqlite(rows, Path("library.db"))
 
 - `psycopg[binary]>=3.1` — PostgreSQL driver
 - `wxyc-etl>=0.1.0` — text normalization (`split_artist_name_contextual`, `is_compilation_artist`)
-- `mysqlclient>=2.0` — C-based MySQL driver with old password auth support (optional, `[mysql]` extra)
+- `pymysql>=1.0` — MySQL driver (optional, `[mysql]` extra)
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,13 +11,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-mysql = ["mariadb>=1.0"]
+mysql = ["pymysql>=1.0"]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-httpx>=0.30.0",
     "ruff>=0.4.0",
-    "mariadb>=1.0",
+    "pymysql>=1.0",
 ]
 
 [project.scripts]

--- a/src/wxyc_catalog/db.py
+++ b/src/wxyc_catalog/db.py
@@ -1,8 +1,9 @@
 """MySQL connection utilities for WXYC catalog databases.
 
-Supports MySQL 4.1+ (Kattare runs MySQL 4.1.22 with old-format password hashes)
-via MariaDB Connector/Python, which maintains backward compatibility with old
-MySQL auth protocols. Falls back to mysqlclient, then pymysql.
+Note: Python MySQL drivers (pymysql, mysqlclient, mysql-connector-python) do not
+support MySQL 4.1's old-format password hashes. The daily library sync workflow
+uses the MariaDB ``mysql`` CLI client instead (see discogs-etl/scripts/sync-library.sh).
+This module works with MySQL 5.x+ servers.
 """
 
 from __future__ import annotations
@@ -10,10 +11,7 @@ from __future__ import annotations
 import logging
 from urllib.parse import unquote, urlparse
 
-try:
-    import pymysql
-except ImportError:
-    pymysql = None  # type: ignore[assignment]
+import pymysql
 
 logger = logging.getLogger(__name__)
 
@@ -21,15 +19,11 @@ logger = logging.getLogger(__name__)
 def connect_mysql(db_url: str):
     """Connect to MySQL using a URL string.
 
-    Tries drivers in order: mariadb (best old-password support), mysqlclient,
-    pymysql. Kattare runs MySQL 4.1.22 with old-format password hashes; the
-    MariaDB connector handles this natively.
-
     Args:
         db_url: MySQL connection URL (mysql://user:pass@host:port/dbname).
 
     Returns:
-        A DB-API 2.0 connection object.
+        A pymysql connection object.
     """
     parsed = urlparse(db_url)
     host = parsed.hostname or "localhost"
@@ -37,38 +31,6 @@ def connect_mysql(db_url: str):
     user = unquote(parsed.username or "root")
     password = unquote(parsed.password or "")
     database = parsed.path.lstrip("/")
-
-    try:
-        import mariadb
-
-        logger.info("Connecting to MySQL via mariadb connector (%s:%d)", host, port)
-        return mariadb.connect(
-            host=host,
-            port=port,
-            user=user,
-            password=password,
-            database=database,
-        )
-    except ImportError:
-        pass
-
-    try:
-        import MySQLdb
-
-        logger.info("Connecting to MySQL via mysqlclient (%s:%d)", host, port)
-        return MySQLdb.connect(
-            host=host,
-            port=port,
-            user=user,
-            passwd=password,
-            db=database,
-            charset="utf8",
-        )
-    except ImportError:
-        pass
-
-    if pymysql is None:
-        raise ImportError("No MySQL driver available (tried mariadb, mysqlclient, pymysql)")
 
     logger.info("Connecting to MySQL via pymysql (%s:%d)", host, port)
     return pymysql.connect(

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -3,250 +3,65 @@
 from __future__ import annotations
 
 import logging
-import sys
-from types import ModuleType
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-DB_URL = "mysql://wxyc:secret@db.example.com:3307/wxycmusic"
-
-
-def _make_mock_module(name: str) -> ModuleType:
-    """Create a mock module with a connect() method."""
-    mod = MagicMock(spec=ModuleType)
-    mod.__name__ = name
-    mod.connect = MagicMock()
-    return mod
+from wxyc_catalog.db import connect_mysql
 
 
 class TestConnectMysql:
-    """connect_mysql() parses a URL and connects via the first available driver."""
+    """connect_mysql() parses a URL and connects via pymysql."""
 
-    def test_parses_full_url(self) -> None:
-        mock_pymysql = _make_mock_module("pymysql")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
-            from importlib import reload
+    @patch("wxyc_catalog.db.pymysql")
+    def test_parses_full_url(self, mock_pymysql) -> None:
+        connect_mysql("mysql://wxyc:secret@db.example.com:3307/wxycmusic")
+        mock_pymysql.connect.assert_called_once_with(
+            host="db.example.com",
+            port=3307,
+            user="wxyc",
+            password="secret",
+            database="wxycmusic",
+            charset="utf8",
+        )
 
-            import wxyc_catalog.db as db_mod
+    @patch("wxyc_catalog.db.pymysql")
+    def test_defaults_for_minimal_url(self, mock_pymysql) -> None:
+        connect_mysql("mysql:///mydb")
+        mock_pymysql.connect.assert_called_once_with(
+            host="localhost",
+            port=3306,
+            user="root",
+            password="",
+            database="mydb",
+            charset="utf8",
+        )
 
-            reload(db_mod)
-            db_mod.connect_mysql("mysql://wxyc:secret@db.example.com:3307/wxycmusic")
-            mock_pymysql.connect.assert_called_once_with(
-                host="db.example.com",
-                port=3307,
-                user="wxyc",
-                password="secret",
-                database="wxycmusic",
-                charset="utf8",
-            )
-
-    def test_defaults_for_minimal_url(self) -> None:
-        mock_pymysql = _make_mock_module("pymysql")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            db_mod.connect_mysql("mysql:///mydb")
-            mock_pymysql.connect.assert_called_once_with(
-                host="localhost",
-                port=3306,
-                user="root",
-                password="",
-                database="mydb",
-                charset="utf8",
-            )
-
-    def test_returns_connection(self) -> None:
-        mock_pymysql = _make_mock_module("pymysql")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            result = db_mod.connect_mysql("mysql://u:p@h/db")
-            assert result == mock_pymysql.connect.return_value
-
-
-# ---------------------------------------------------------------------------
-# Driver fallback chain
-# ---------------------------------------------------------------------------
-
-
-class TestDriverFallbackChain:
-    """connect_mysql() tries mariadb, then mysqlclient, then pymysql."""
-
-    def test_uses_mariadb_when_available(self) -> None:
-        mock_mariadb = _make_mock_module("mariadb")
-        with patch.dict(sys.modules, {"mariadb": mock_mariadb}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            db_mod.connect_mysql(DB_URL)
-            mock_mariadb.connect.assert_called_once()
-
-    def test_falls_back_to_mysqlclient_when_mariadb_unavailable(self) -> None:
-        mock_mysqldb = _make_mock_module("MySQLdb")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": mock_mysqldb}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            db_mod.connect_mysql(DB_URL)
-            mock_mysqldb.connect.assert_called_once()
-            # mysqlclient uses passwd= and db= instead of password= and database=
-            call_kwargs = mock_mysqldb.connect.call_args.kwargs
-            assert "passwd" in call_kwargs
-            assert "db" in call_kwargs
-
-    def test_falls_back_to_pymysql_when_both_unavailable(self) -> None:
-        mock_pymysql = _make_mock_module("pymysql")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            db_mod.connect_mysql(DB_URL)
-            mock_pymysql.connect.assert_called_once()
-
-    def test_mariadb_connect_returns_connection(self) -> None:
-        mock_mariadb = _make_mock_module("mariadb")
-        sentinel = object()
-        mock_mariadb.connect.return_value = sentinel
-        with patch.dict(sys.modules, {"mariadb": mock_mariadb}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            result = db_mod.connect_mysql(DB_URL)
-            assert result is sentinel
-
-    def test_mysqlclient_connect_returns_connection(self) -> None:
-        mock_mysqldb = _make_mock_module("MySQLdb")
-        sentinel = object()
-        mock_mysqldb.connect.return_value = sentinel
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": mock_mysqldb}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            result = db_mod.connect_mysql(DB_URL)
-            assert result is sentinel
-
-
-# ---------------------------------------------------------------------------
-# URL decoding
-# ---------------------------------------------------------------------------
+    @patch("wxyc_catalog.db.pymysql")
+    def test_returns_connection(self, mock_pymysql) -> None:
+        result = connect_mysql("mysql://u:p@h/db")
+        assert result == mock_pymysql.connect.return_value
 
 
 class TestUrlDecoding:
     """connect_mysql() URL-decodes username and password."""
 
-    def test_url_decodes_username(self) -> None:
-        mock_pymysql = _make_mock_module("pymysql")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
-            from importlib import reload
+    @patch("wxyc_catalog.db.pymysql")
+    def test_url_decodes_username(self, mock_pymysql) -> None:
+        connect_mysql("mysql://wxyc%40host:secret@db.example.com:3306/wxycmusic")
+        call_kwargs = mock_pymysql.connect.call_args.kwargs
+        assert call_kwargs["user"] == "wxyc@host"
 
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            db_mod.connect_mysql("mysql://wxyc%40host:secret@db.example.com:3306/wxycmusic")
-            call_kwargs = mock_pymysql.connect.call_args.kwargs
-            assert call_kwargs["user"] == "wxyc@host"
-
-    def test_url_decodes_password_with_special_chars(self) -> None:
-        mock_pymysql = _make_mock_module("pymysql")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            db_mod.connect_mysql("mysql://wxyc:p%40ss%23w0rd@db.example.com:3306/wxycmusic")
-            call_kwargs = mock_pymysql.connect.call_args.kwargs
-            assert call_kwargs["password"] == "p@ss#w0rd"
-
-
-# ---------------------------------------------------------------------------
-# Charset parameter
-# ---------------------------------------------------------------------------
-
-
-class TestCharsetParameter:
-    """mysqlclient and pymysql get charset='utf8'; mariadb does not."""
-
-    def test_mysqlclient_passes_charset_utf8(self) -> None:
-        mock_mysqldb = _make_mock_module("MySQLdb")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": mock_mysqldb}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            db_mod.connect_mysql(DB_URL)
-            call_kwargs = mock_mysqldb.connect.call_args.kwargs
-            assert call_kwargs["charset"] == "utf8"
-
-    def test_pymysql_passes_charset_utf8(self) -> None:
-        mock_pymysql = _make_mock_module("pymysql")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            db_mod.connect_mysql(DB_URL)
-            call_kwargs = mock_pymysql.connect.call_args.kwargs
-            assert call_kwargs["charset"] == "utf8"
-
-    def test_mariadb_does_not_pass_charset(self) -> None:
-        mock_mariadb = _make_mock_module("mariadb")
-        with patch.dict(sys.modules, {"mariadb": mock_mariadb}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            db_mod.connect_mysql(DB_URL)
-            call_kwargs = mock_mariadb.connect.call_args.kwargs
-            assert "charset" not in call_kwargs
-
-
-# ---------------------------------------------------------------------------
-# Logging
-# ---------------------------------------------------------------------------
+    @patch("wxyc_catalog.db.pymysql")
+    def test_url_decodes_password_with_special_chars(self, mock_pymysql) -> None:
+        connect_mysql("mysql://wxyc:p%40ss%23w0rd@db.example.com:3306/wxycmusic")
+        call_kwargs = mock_pymysql.connect.call_args.kwargs
+        assert call_kwargs["password"] == "p@ss#w0rd"
 
 
 class TestDriverLogging:
-    """connect_mysql() logs which driver is being used."""
+    """connect_mysql() logs connection info."""
 
-    def test_logs_mariadb_driver_info(self, caplog) -> None:
-        mock_mariadb = _make_mock_module("mariadb")
-        with patch.dict(sys.modules, {"mariadb": mock_mariadb}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            with caplog.at_level(logging.INFO, logger="wxyc_catalog.db"):
-                db_mod.connect_mysql(DB_URL)
-            assert "mariadb connector" in caplog.text.lower()
-
-    def test_logs_pymysql_driver_info(self, caplog) -> None:
-        mock_pymysql = _make_mock_module("pymysql")
-        with patch.dict(sys.modules, {"mariadb": None, "MySQLdb": None, "pymysql": mock_pymysql}):
-            from importlib import reload
-
-            import wxyc_catalog.db as db_mod
-
-            reload(db_mod)
-            with caplog.at_level(logging.INFO, logger="wxyc_catalog.db"):
-                db_mod.connect_mysql(DB_URL)
-            assert "pymysql" in caplog.text.lower()
+    @patch("wxyc_catalog.db.pymysql")
+    def test_logs_pymysql_driver_info(self, mock_pymysql, caplog) -> None:
+        with caplog.at_level(logging.INFO, logger="wxyc_catalog.db"):
+            connect_mysql("mysql://u:p@db.example.com:3306/mydb")
+        assert "pymysql" in caplog.text.lower()


### PR DESCRIPTION
## Summary
- Remove mariadb and mysqlclient fallback paths from `connect_mysql()`
- Keep pymysql-only with URL decoding
- Simplify tests to remove fallback chain coverage
- Update README MySQL 4.1 compatibility section and dependencies

Closes #15

## Test plan
- [x] 7 unit tests pass (URL parsing, defaults, return value, URL decoding, logging)
- [x] Ruff clean