### PR TITLE
Add slow marker to pytest configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ markers = [
     "integration: needs external service or fixture data",
     "e2e: full pipeline end-to-end test",
     "parity: old vs new implementation comparison",
+    "slow: marks tests as slow",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not parity'"
+addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
 testpaths = ["tests"]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

Adds the \`slow\` marker to align with the canonical 6-marker WXYC ETL block defined in the org-local \`plans/test-patterns.md\`. Updates \`addopts\` to deselect \`slow\` from the default \`pytest\` run so \`pytest\` with no arguments continues to surface only unit tests.

The other five canonical markers (\`unit\`, \`postgres\`, \`integration\`, \`e2e\`, \`parity\`) were already in place.

Part of WXYC/wxyc-etl#23 (test pattern standardization across ETL repos). PR-A5 of the planned chain.

## Audit notes (not in scope but worth recording)

- \`tests/factories.py\` already uses canonical WXYC artists (Juana Molina, Stereolab, Cat Power, Jessica Pratt, Chuquimamani-Condori) — no fixture migration needed in this repo
- A grep across \`tests/\` found no mainstream-artist references

## Test plan

- [x] \`pytest --markers\` lists all 6 canonical markers including \`slow\`
- [x] \`pytest -m slow --co\` no longer reports an unknown-marker warning
- [ ] CI green