### PR TITLE
ci: run integration tests and add marker-sync guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,30 @@ jobs:
           pip install -e .
           pip install pytest pytest-asyncio pytest-httpx
       - run: pytest tests/unit/ -v
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install wxyc-etl from git (Rust/PyO3)
+        run: |
+          pip install maturin
+          git clone --depth 1 --branch etl-unification/1g-pyo3-bindings https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
+          cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
+      - name: Install package and test dependencies
+        run: |
+          pip install pymysql
+          pip install -e .
+          pip install pytest pytest-asyncio pytest-httpx
+      - run: pytest tests/integration/ -v -m "integration"
+
+  marker-sync:
+    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+    with:
+      repo-path: "."
+      workflows-dir: ".github/workflows"
+      tests-dir: "tests"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pytest -m integration     # integration tests (SQLite-based, no external DB)
 pytest -m '' -v           # all tests
 ```
 
-Markers in use: `unit`, `integration`, `slow`. The `addopts` in `pyproject.toml` excludes `integration` and `slow` from the default run; CI runs them in a dedicated `integration` job. (Orphan markers `postgres`, `e2e`, `parity` were removed — re-add them if/when actual tests appear.)
+Markers follow the canonical WXYC 6-marker convention (`unit`, `postgres`, `integration`, `e2e`, `parity`, `slow`) declared in every Python repo for org-wide consistency (see `plans/test-patterns.md`). The `addopts` in `pyproject.toml` deselects everything except `unit` so `pytest` with no arguments runs only unit tests. CI runs `integration` in a dedicated job; the marker-sync workflow guards against silent-deselection regressions for any marker actually used by a test in this repo.
 
 ### Test Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ pytest -m integration     # integration tests (SQLite-based, no external DB)
 pytest -m '' -v           # all tests
 ```
 
-Markers follow the standard WXYC convention (`unit`, `postgres`, `integration`, `e2e`, `parity`). The `addopts` in `pyproject.toml` excludes non-unit markers from the default run.
+Markers in use: `unit`, `integration`, `slow`. The `addopts` in `pyproject.toml` excludes `integration` and `slow` from the default run; CI runs them in a dedicated `integration` job. (Orphan markers `postgres`, `e2e`, `parity` were removed — re-add them if/when actual tests appear.)
 
 ### Test Layout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,17 @@ target-version = "py311"
 select = ["E", "F", "I", "W"]
 
 [tool.pytest.ini_options]
+# Canonical WXYC 6-marker block (see plans/test-patterns.md). All Python repos
+# declare the same six markers with identical semantics for org-wide
+# consistency, even when this repo has no test currently using a given marker.
 markers = [
     "unit: pure logic tests, no external dependencies",
+    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
     "integration: needs external service or fixture data",
+    "e2e: full pipeline end-to-end test",
+    "parity: old vs new implementation comparison",
     "slow: marks tests as slow",
 ]
-addopts = "-m 'not integration and not slow'"
+addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,9 @@ select = ["E", "F", "I", "W"]
 [tool.pytest.ini_options]
 markers = [
     "unit: pure logic tests, no external dependencies",
-    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
     "integration: needs external service or fixture data",
-    "e2e: full pipeline end-to-end test",
-    "parity: old vs new implementation comparison",
     "slow: marks tests as slow",
 ]
-addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
+addopts = "-m 'not integration and not slow'"
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/tests/integration/test_export_pipeline.py
+++ b/tests/integration/test_export_pipeline.py
@@ -65,6 +65,7 @@ class TestExportPipeline:
             "genre",
             "format",
             "alternate_artist_name",
+            "label",
         }
         assert columns == expected
 
@@ -272,6 +273,7 @@ class TestPreExistingIncompatibleSchema:
             "genre",
             "format",
             "alternate_artist_name",
+            "label",
         }
         assert columns == expected
 


### PR DESCRIPTION
## Summary

The `test` job invoked `pytest tests/unit/`, and `pyproject.toml` `addopts` deselects `integration` by default. The integration suite in `tests/integration/test_export_pipeline.py` was therefore never executed by CI, masking schema drift in the export pipeline.

This is the same structural failure mode as WXYC/discogs-etl#103.

## Changes

- Add an `integration` job to `.github/workflows/ci.yml` mirroring the `test` job's setup that runs `pytest tests/integration/ -v -m "integration"`.
- Wire in the reusable `WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml` workflow as a `marker-sync` job to prevent this class of bug from regressing.
- Fix two integration tests whose expected column set was stale: the `label` column was added to the export schema in 0b29dfb without updating the integration assertions. This is exactly the silent drift the missing CI job was hiding.
- Drop orphan markers `postgres`, `e2e`, `parity` from `pyproject.toml` (declared but never used by any test). Keep `slow` since it was just added intentionally in dd4a5ee.
- Update CLAUDE.md to reflect the cleaned marker list.

## Test plan

- [x] `pytest tests/integration/ -v -m integration` passes locally (20/20)
- [x] `pytest tests/unit/ -v` still passes (107/107)
- [x] `ruff check .` and `ruff format --check .` clean
- [x] `python3 scripts/check_marker_ci_sync.py --repo-path .` (from WXYC/wxyc-etl) reports PASS
- [ ] All four CI jobs (`lint`, `test`, `integration`, `marker-sync`) succeed

Closes #18