### PR TITLE
chore: migrate pytest markers to architecture A

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,27 +36,7 @@ jobs:
           pip install pymysql
           pip install -e .
           pip install pytest pytest-asyncio pytest-httpx
-      - run: pytest tests/unit/ -v
-
-  integration:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install wxyc-etl from git (Rust/PyO3)
-        run: |
-          pip install maturin
-          git clone --depth 1 --branch etl-unification/1g-pyo3-bindings https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
-      - name: Install package and test dependencies
-        run: |
-          pip install pymysql
-          pip install -e .
-          pip install pytest pytest-asyncio pytest-httpx
-      - run: pytest tests/integration/ -v -m "integration"
+      - run: pytest tests/ -v
 
   marker-sync:
     uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,12 @@ src/wxyc_catalog/
 ## Testing
 
 ```bash
-pytest                    # unit tests only (default, no external deps)
-pytest -m integration     # integration tests (SQLite-based, no external DB)
-pytest -m '' -v           # all tests
+pytest                    # all tests (no markers needed — this repo has no infra deps)
+pytest tests/unit/ -v     # unit tests only
+pytest tests/integration/ # integration tests only (SQLite-based)
 ```
 
-Markers follow the canonical WXYC 6-marker convention (`unit`, `postgres`, `integration`, `e2e`, `parity`, `slow`) declared in every Python repo for org-wide consistency (see `plans/test-patterns.md`). The `addopts` in `pyproject.toml` deselects everything except `unit` so `pytest` with no arguments runs only unit tests. CI runs `integration` in a dedicated job; the marker-sync workflow guards against silent-deselection regressions for any marker actually used by a test in this repo.
+Markers follow architecture A (see `plans/test-patterns.md`, Section 3): markers exist to route CI by infrastructure, and wxyc-catalog has no infrastructure dependencies — it is SQLite-only with no PostgreSQL, no external APIs, and no docker stack. The repo therefore declares zero markers in `pyproject.toml`. The tests in `tests/integration/` are unmarked and run alongside `tests/unit/` in the default `test` CI job. The `marker-sync` CI job (reusable workflow from wxyc-etl) guards against silent-deselection regressions if markers are ever introduced.
 
 ### Test Layout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,17 +40,10 @@ target-version = "py311"
 select = ["E", "F", "I", "W"]
 
 [tool.pytest.ini_options]
-# Canonical WXYC 6-marker block (see plans/test-patterns.md). All Python repos
-# declare the same six markers with identical semantics for org-wide
-# consistency, even when this repo has no test currently using a given marker.
-markers = [
-    "unit: pure logic tests, no external dependencies",
-    "postgres: needs PostgreSQL (gated by DATABASE_URL_TEST)",
-    "integration: needs external service or fixture data",
-    "e2e: full pipeline end-to-end test",
-    "parity: old vs new implementation comparison",
-    "slow: marks tests as slow",
-]
-addopts = "-m 'not integration and not postgres and not e2e and not parity and not slow'"
+# Architecture A (see plans/test-patterns.md, Section 3): markers exist to route
+# CI by infrastructure. wxyc-catalog has no infrastructure dependencies — it is
+# SQLite-only with no PostgreSQL, no external APIs, and no docker stack — so it
+# declares no markers. The tests in tests/integration/ are unmarked and run in
+# the default test job alongside tests/unit/.
 testpaths = ["tests"]
 asyncio_mode = "auto"

--- a/tests/integration/test_export_pipeline.py
+++ b/tests/integration/test_export_pipeline.py
@@ -19,8 +19,6 @@ from wxyc_catalog.enrich_library_artists import extract_base_artists, merge_and_
 from wxyc_catalog.export_to_sqlite import export_rows_to_sqlite
 from wxyc_catalog.extract_library_labels import write_library_labels_csv
 
-pytestmark = pytest.mark.integration
-
 
 class TestExportPipeline:
     """Full export flow: rows -> SQLite library.db with FTS5."""


### PR DESCRIPTION
## Summary

Migrates wxyc-catalog from the legacy 6-marker pytest scheme (`unit / postgres / integration / e2e / parity / slow`) to **architecture A** as defined in `plans/test-patterns.md`, Section 3. This is the smallest such migration of any WXYC repo, because wxyc-catalog has no infrastructure dependencies — it is SQLite-only with no PostgreSQL service, no external APIs, and no docker-compose stack.

Under architecture A, markers exist purely to **route CI by infrastructure**. Per the migration table in Section 3:

| Legacy | Used in this repo? | Mapped to |
|---|---|---|
| `unit` | no `@pytest.mark.unit` calls | (default — no marker) |
| `postgres` | no PG tests | (n/a, dropped) |
| `integration` | 1 file (`test_export_pipeline.py`), SQLite-only | unmarked, runs in default `test` job |
| `e2e` | no e2e tests | (n/a, dropped) |
| `parity` | no parity tests | (n/a, dropped) |
| `slow` | declared in #19, never applied to any test | (n/a, dropped) |

Net result: **the repo declares zero markers**.

## Changes

- `pyproject.toml`: drop the entire `markers` list and `addopts`; replace with a comment explaining why architecture A leaves wxyc-catalog markerless.
- `tests/integration/test_export_pipeline.py`: drop `pytestmark = pytest.mark.integration`. The directory name survives for taxonomy/documentation per the architecture-A directory layout.
- `.github/workflows/ci.yml`: drop the now-redundant `integration` job. The `test` job now runs `pytest tests/` (the whole tree) instead of `pytest tests/unit/`, so integration-tier tests still execute — they just run unmarked alongside the unit tests. The `marker-sync` reusable workflow stays in place to guard against future silent-deselection regressions if markers are ever re-introduced.
- `CLAUDE.md`: update the Testing section to describe architecture A.

## Test plan

- [x] `pytest tests/` locally — 169 passed (was 169 passed across two jobs before; the integration tier did not regress)
- [x] `ruff check .` and `ruff format --check .` — clean
- [x] `python3 scripts/check_marker_ci_sync.py --repo-path .` — PASS (no markers used, no markers declared, no addopts, `test` job runs without `-m`, so the sync invariant trivially holds)
- [ ] CI green on this PR (`lint`, `test`, `marker-sync`)

## References

- `plans/test-patterns.md` Section 3 (Marker Conventions) — defines architecture A and the migration table
- PR #19 — restored the canonical 6-marker block and added the marker-sync guardrail; this PR builds on that by completing the migration to A