### PR TITLE
ci: install wxyc-etl from PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,17 +25,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install wxyc-etl from git (Rust/PyO3)
-        run: |
-          pip install maturin
-          git clone --depth 1 --branch etl-unification/1g-pyo3-bindings https://github.com/WXYC/wxyc-etl.git /tmp/wxyc-etl
-          cd /tmp/wxyc-etl/wxyc-etl-python && maturin build --release && pip install /tmp/wxyc-etl/target/wheels/*.whl
       - name: Install package and test dependencies
-        run: |
-          pip install pymysql
-          pip install -e .
-          pip install pytest pytest-asyncio pytest-httpx
+        run: pip install -e ".[dev]"
       - run: pytest tests/ -v
 
   marker-sync:


### PR DESCRIPTION
## Summary

- Drop the `git clone` + `maturin build` bootstrap for wxyc-etl in CI now that wxyc-etl 0.1.0 is on PyPI.
- The pyproject already declares `wxyc-etl>=0.1.0`, so `pip install -e ".[dev]"` resolves it directly.
- Remove the unused `dtolnay/rust-toolchain@stable` step (this is a Python-only repo).

## Verification

Locally in a fresh venv:
```sh
pip install -e ".[dev]"
python -c "from wxyc_etl import text; print('ok')"
pytest tests/ -q   # 169 passed
ruff check . && ruff format --check .
```

## Note

This is the wxyc-catalog *consumer* migration. Publishing wxyc-catalog itself to PyPI is out of scope — discogs-etl will keep its `git clone wxyc-catalog` step until that follow-up lands.

Closes #21

## Tracking

Parent: WXYC/wxyc-etl#46 — [Epic] Publish wxyc-etl + wxyc-etl-python
Phase: B
Project: https://github.com/orgs/WXYC/projects/19