### PR TITLE
ci: tag-driven release.yml for PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: Release
+
+# Tag-driven publish to PyPI for wxyc-catalog. Mirrors the wxyc-etl release
+# workflow, sans maturin — wxyc-catalog is pure Python with a setuptools build.
+#
+#   git tag v0.1.0 && git push origin v0.1.0
+#
+# A `workflow_dispatch` run with `dry_run: true` (the default) is the safe way
+# to rehearse the pipeline without uploading. It runs the full version check +
+# `python -m build` and skips the actual upload step.
+#
+# Required repo secret (set up once in GitHub → Settings → Secrets):
+#   PYPI_API_TOKEN  — API token from https://pypi.org/manage/account/token/
+#                     (scope it to the `wxyc-catalog` project after first publish)
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Skip PyPI upload (rehearsal mode)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: v
+        name: Verify pyproject.toml version matches tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROJECT_VERSION=$(awk -F'"' '/^version =/ { print $2; exit }' pyproject.toml)
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+            if [[ "$TAG_VERSION" != "$PROJECT_VERSION" ]]; then
+              echo "::error ::Tag $TAG_VERSION does not match pyproject.toml version $PROJECT_VERSION"
+              exit 1
+            fi
+          fi
+          echo "Project version: $PROJECT_VERSION"
+          echo "version=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist + wheel
+        run: |
+          pip install --upgrade build
+          python -m build
+      - name: List artifacts
+        run: ls -la dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - name: Skip upload (dry-run)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+        run: |
+          echo "Dry-run mode: would upload the following artifacts:"
+          ls -la dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run) }}
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,29 @@ tests/
 ### Test Fixtures
 
 Use WXYC-representative artist data (not mainstream): Juana Molina, Stereolab, Cat Power, Jessica Pratt, Chuquimamani-Condori, Sessa, Duke Ellington & John Coltrane, etc. Factory functions in `tests/factories.py` provide canonical defaults aligned with `wxyc-shared/src/test-utils/wxyc-example-data.json`.
+
+## Releases
+
+`wxyc-catalog` is published to PyPI as the `wxyc-catalog` distribution. Releases are tag-driven via `.github/workflows/release.yml`:
+
+```bash
+# Bump pyproject.toml version, commit, then:
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The workflow verifies the tag matches `pyproject.toml`, builds an sdist + wheel with `python -m build`, and uploads via `pypa/gh-action-pypi-publish`. The workflow's `workflow_dispatch` trigger with `dry_run: true` (default) is a rehearsal that runs everything except the upload — useful for shaking out build issues without burning a version number.
+
+**One-time operator setup**: a `PYPI_API_TOKEN` repo secret is required. Generate at https://pypi.org/manage/account/token/; on first publish use an account-scoped token, then narrow it to the `wxyc-catalog` project once the project exists on PyPI. Trusted Publishing (OIDC) is a future migration; the current workflow uses token auth to match the wxyc-etl precedent.
+
+External consumers depend on the published version:
+
+```toml
+# discogs-etl pyproject.toml, etc.
+dependencies = [
+    "wxyc-catalog>=0.1.0",
+    ...
+]
+```
+
+Once the package is on PyPI, the `git clone https://github.com/WXYC/wxyc-catalog` step in `discogs-etl/.github/workflows/rebuild-cache.yml` (and any sibling workflow) can be dropped — `pip install -e ".[dev]"` resolves wxyc-catalog from PyPI directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "wxyc-catalog"
 version = "0.1.0"
 description = "WXYC library catalog access and operations — CatalogSource protocol, SQLite export, artist enrichment, label extraction."
+readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "asyncpg>=0.29.0",
@@ -9,6 +10,11 @@ dependencies = [
     "psycopg[binary]>=3.1",
     "wxyc-etl>=0.1.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/WXYC/wxyc-catalog"
+Repository = "https://github.com/WXYC/wxyc-catalog"
+Issues = "https://github.com/WXYC/wxyc-catalog/issues"
 
 [project.optional-dependencies]
 mysql = ["pymysql>=1.0"]


### PR DESCRIPTION
Closes #24.

## Summary

Adds `.github/workflows/release.yml` so `wxyc-catalog` can ship to PyPI tag-driven, mirroring the wxyc-etl publishing pattern minus maturin (this repo is pure Python).

`pyproject.toml` gains `readme = "README.md"` and `[project.urls]` so the PyPI listing renders the long description and sidebar links. `CLAUDE.md` gains a Releases section.

## Why now

`wxyc-catalog` is the last `git clone`-installed dependency in the WXYC ETL family. Every other shared package (`wxyc-etl`, `wxyc-etl-python`) shipped to PyPI in Phase B; this repo lagged. The remaining consumers (`discogs-etl/.github/workflows/rebuild-cache.yml`, `discogs-etl`'s `pip install -e ".[dev]"` flow) all keep needing a `git clone https://github.com/WXYC/wxyc-catalog.git` step. Closing this gap is also a soft prerequisite for Phase E so the monorepo move can archive this repo cleanly.

## Workflow shape

- **`verify`**: reads `version` out of `pyproject.toml` and confirms it matches the pushed tag (`refs/tags/vX.Y.Z` → `X.Y.Z`).
- **`build`**: runs `python -m build` for sdist + wheel.
- **`publish-pypi`**: downloads artifacts, uploads via `pypa/gh-action-pypi-publish@release/v1` with `skip-existing: true`. Skipped under `workflow_dispatch` with `dry_run: true` (the default), so rehearsals exercise the verify+build path without burning a version number.

Triggers: `push` of `v*.*.*` tags (publish path) and `workflow_dispatch` (rehearsal path). Default `dry_run: true` means an accidental "Run workflow" click won't ship anything.

## Local verification

`python -m build` builds a clean sdist + wheel with the new metadata:

```
Metadata-Version: 2.4
Name: wxyc-catalog
Version: 0.1.0
Project-URL: Homepage, https://github.com/WXYC/wxyc-catalog
Project-URL: Repository, https://github.com/WXYC/wxyc-catalog
Project-URL: Issues, https://github.com/WXYC/wxyc-catalog/issues
Description-Content-Type: text/markdown
...
```

169 unit tests + ruff lint + ruff format clean.

## Operator action required after merge

Before tagging `v0.1.0`:

1. Generate a PyPI API token at https://pypi.org/manage/account/token/. First publish needs an account-scoped token; once the project exists on PyPI, scope it to the `wxyc-catalog` project.
2. Add it as repo secret `PYPI_API_TOKEN`.
3. Rehearse with `gh workflow run release.yml -f dry_run=true` — should build cleanly, skip upload.
4. Tag and push: `git tag v0.1.0 && git push origin v0.1.0`.

## Cleanup follow-ups (separate PRs, after first publish)

- `discogs-etl` PR to drop the `git clone wxyc-catalog` step from `rebuild-cache.yml` and `sync-library.yml` if applicable — `wxyc-catalog>=0.1.0` already declared in those pyprojects, so `pip install -e ".[dev]"` will resolve from PyPI directly.
- Same in any other repo that still git-installs `wxyc-catalog`.