### PR TITLE
db: lazy-import pymysql so wxyc_catalog imports without it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wxyc-catalog"
-version = "0.1.0"
+version = "0.1.1"
 description = "WXYC library catalog access and operations — CatalogSource protocol, SQLite export, artist enrichment, label extraction."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/wxyc_catalog/db.py
+++ b/src/wxyc_catalog/db.py
@@ -4,14 +4,17 @@ Note: Python MySQL drivers (pymysql, mysqlclient, mysql-connector-python) do not
 support MySQL 4.1's old-format password hashes. The daily library sync workflow
 uses the MariaDB ``mysql`` CLI client instead (see discogs-etl/scripts/sync-library.sh).
 This module works with MySQL 5.x+ servers.
+
+``pymysql`` is imported lazily inside ``connect_mysql()`` so consumers that
+only use the SQLite export or the PG ``BackendServiceSource`` don't have to
+install it. The package's ``[mysql]`` extra still pulls it for users that
+do call this function.
 """
 
 from __future__ import annotations
 
 import logging
 from urllib.parse import unquote, urlparse
-
-import pymysql
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +27,20 @@ def connect_mysql(db_url: str):
 
     Returns:
         A pymysql connection object.
+
+    Raises:
+        ImportError: ``pymysql`` is not installed. Install ``wxyc-catalog[mysql]``
+            to pull it in, or fall back to the MariaDB CLI path used by
+            ``scripts/sync-library.sh`` for MySQL 4.1 servers.
     """
+    try:
+        import pymysql
+    except ImportError as exc:
+        raise ImportError(
+            "pymysql is required for connect_mysql(). Install it via "
+            "`pip install wxyc-catalog[mysql]` (or directly: `pip install pymysql`)."
+        ) from exc
+
     parsed = urlparse(db_url)
     host = parsed.hostname or "localhost"
     port = parsed.port or 3306

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
+import sys
 from unittest.mock import patch
+
+import pytest
 
 from wxyc_catalog.db import connect_mysql
 
@@ -11,10 +15,10 @@ from wxyc_catalog.db import connect_mysql
 class TestConnectMysql:
     """connect_mysql() parses a URL and connects via pymysql."""
 
-    @patch("wxyc_catalog.db.pymysql")
-    def test_parses_full_url(self, mock_pymysql) -> None:
+    @patch("pymysql.connect")
+    def test_parses_full_url(self, mock_connect) -> None:
         connect_mysql("mysql://wxyc:secret@db.example.com:3307/wxycmusic")
-        mock_pymysql.connect.assert_called_once_with(
+        mock_connect.assert_called_once_with(
             host="db.example.com",
             port=3307,
             user="wxyc",
@@ -23,10 +27,10 @@ class TestConnectMysql:
             charset="utf8",
         )
 
-    @patch("wxyc_catalog.db.pymysql")
-    def test_defaults_for_minimal_url(self, mock_pymysql) -> None:
+    @patch("pymysql.connect")
+    def test_defaults_for_minimal_url(self, mock_connect) -> None:
         connect_mysql("mysql:///mydb")
-        mock_pymysql.connect.assert_called_once_with(
+        mock_connect.assert_called_once_with(
             host="localhost",
             port=3306,
             user="root",
@@ -35,33 +39,62 @@ class TestConnectMysql:
             charset="utf8",
         )
 
-    @patch("wxyc_catalog.db.pymysql")
-    def test_returns_connection(self, mock_pymysql) -> None:
+    @patch("pymysql.connect")
+    def test_returns_connection(self, mock_connect) -> None:
         result = connect_mysql("mysql://u:p@h/db")
-        assert result == mock_pymysql.connect.return_value
+        assert result == mock_connect.return_value
 
 
 class TestUrlDecoding:
     """connect_mysql() URL-decodes username and password."""
 
-    @patch("wxyc_catalog.db.pymysql")
-    def test_url_decodes_username(self, mock_pymysql) -> None:
+    @patch("pymysql.connect")
+    def test_url_decodes_username(self, mock_connect) -> None:
         connect_mysql("mysql://wxyc%40host:secret@db.example.com:3306/wxycmusic")
-        call_kwargs = mock_pymysql.connect.call_args.kwargs
+        call_kwargs = mock_connect.call_args.kwargs
         assert call_kwargs["user"] == "wxyc@host"
 
-    @patch("wxyc_catalog.db.pymysql")
-    def test_url_decodes_password_with_special_chars(self, mock_pymysql) -> None:
+    @patch("pymysql.connect")
+    def test_url_decodes_password_with_special_chars(self, mock_connect) -> None:
         connect_mysql("mysql://wxyc:p%40ss%23w0rd@db.example.com:3306/wxycmusic")
-        call_kwargs = mock_pymysql.connect.call_args.kwargs
+        call_kwargs = mock_connect.call_args.kwargs
         assert call_kwargs["password"] == "p@ss#w0rd"
 
 
 class TestDriverLogging:
     """connect_mysql() logs connection info."""
 
-    @patch("wxyc_catalog.db.pymysql")
-    def test_logs_pymysql_driver_info(self, mock_pymysql, caplog) -> None:
+    @patch("pymysql.connect")
+    def test_logs_pymysql_driver_info(self, mock_connect, caplog) -> None:
         with caplog.at_level(logging.INFO, logger="wxyc_catalog.db"):
             connect_mysql("mysql://u:p@db.example.com:3306/mydb")
         assert "pymysql" in caplog.text.lower()
+
+
+class TestPymysqlImportIsLazy:
+    """Module-load doesn't require pymysql to be installed.
+
+    Regression: ``wxyc_catalog`` is consumed by services that don't use the
+    MySQL TubafrenzySource at all (just the SQLite export path or the PG
+    BackendServiceSource). Forcing them to install pymysql to even
+    ``import wxyc_catalog`` is a wart we want to keep out — particularly
+    after the publish-to-PyPI cleanup, where discogs-etl had to declare
+    ``wxyc-catalog[mysql]`` to keep the import chain resolving.
+    """
+
+    def test_db_module_imports_without_pymysql(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Setting sys.modules['pymysql'] = None makes subsequent `import pymysql`
+        # raise ImportError — the standard trick for masking optional deps.
+        monkeypatch.setitem(sys.modules, "pymysql", None)
+        # Force a fresh import of db so the masked pymysql is what it sees.
+        monkeypatch.delitem(sys.modules, "wxyc_catalog.db", raising=False)
+        importlib.import_module("wxyc_catalog.db")  # must not raise
+
+    def test_connect_mysql_raises_clear_error_when_pymysql_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(sys.modules, "pymysql", None)
+        monkeypatch.delitem(sys.modules, "wxyc_catalog.db", raising=False)
+        db = importlib.import_module("wxyc_catalog.db")
+        with pytest.raises(ImportError, match=r"pymysql"):
+            db.connect_mysql("mysql://u:p@h/d")


### PR DESCRIPTION
Closes #26.

## Summary

Move `import pymysql` from module top level into `connect_mysql()` itself, wrapped in a try/except that raises a clearer ImportError when missing. Any `import wxyc_catalog` succeeds without pymysql installed; only callers of `connect_mysql()` need it.

The publish-to-PyPI cleanup in WXYC/discogs-etl#135 caught the latent issue. Workaround there was `wxyc-catalog[mysql]>=0.1.0`, pulling pymysql into every consumer regardless of whether they ever call `connect_mysql()`. With 0.1.1, that extra becomes optional.

## Tests

171 passed (up from 169, +2 new regression tests in `TestPymysqlImportIsLazy`):
- `test_db_module_imports_without_pymysql` — `import wxyc_catalog.db` succeeds when pymysql is masked via `sys.modules['pymysql'] = None`.
- `test_connect_mysql_raises_clear_error_when_pymysql_missing` — calling `connect_mysql()` in that state raises ImportError with "pymysql" in the message.

Existing `@patch("wxyc_catalog.db.pymysql")` patches were rewritten to target `pymysql.connect` directly (the module attribute no longer exists).

ruff clean.

## Versioning

Bumps to **0.1.1**. Strict superset — consumers on 0.1.0 keep working unchanged.

## Operator action after merge

```sh
git tag v0.1.1 origin/main
git push origin v0.1.1
```

Triggers `release.yml`. The `PYPI_API_TOKEN` secret is already in place from the 0.1.0 publish.

## Follow-up

Once 0.1.1 is on PyPI, discogs-etl can pin `wxyc-catalog>=0.1.1` and drop the `[mysql]` extra (it never calls `connect_mysql()` — it uses the MariaDB CLI subprocess for MySQL 4.1 compat).