### PR TITLE
Pin reusable workflow refs to gha/v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,9 @@ jobs:
       - run: pytest tests/ -v
 
   marker-sync:
-    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@main
+    uses: WXYC/wxyc-etl/.github/workflows/check-ci-marker-sync.yml@gha/v1
     with:
       repo-path: "."
       workflows-dir: ".github/workflows"
       tests-dir: "tests"
+      wxyc-etl-ref: gha/v1


### PR DESCRIPTION
## Summary

Pins reusable workflow refs from `@main` to the new `gha/v1` stability tags on `wxyc-shared` / `wxyc-etl`, and passes the matching `*-ref` input so the inner script checkout in each reusable workflow stays pinned (default was `main`).

## Why

Before this PR, a push to `wxyc-shared/main` or `wxyc-etl/main` would cascade into this repo's CI with this repo's secrets. The new `gha/v1` stability tags provide a pin-able ref. Tag policy: `gha/v1` moves for non-breaking updates; `gha/v2` for breaking changes.

## Project

Part of [GitHub Actions Supply-Chain Hardening](https://github.com/orgs/WXYC/projects/31), Phase 2.

## Test plan

- [ ] Reusable-workflow jobs still pass after merge.